### PR TITLE
fix/social-auth-500-stage-2

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -240,6 +240,7 @@ SOCIALACCOUNT_ADAPTER = 'users.adapters.SocialAccountAdapter'
 SOCIALACCOUNT_QUERY_EMAIL = True  # запрашивать email у провайдера
 SOCIALACCOUNT_EMAIL_AUTHENTICATION = True  # разрешить вход по email из соцсети
 SOCIALACCOUNT_EMAIL_AUTHENTICATION_AUTO_CONNECT = True  # автоматически связывать
+ACCOUNT_EMAIL_VERIFICATION = False
 SOCIALACCOUNT_LOGIN_ON_GET = True  # сразу редиректить вход без промежуточной страницы
 FRONTEND_SOCIAL_AUTH_URL = os.getenv(
     'FRONTEND_SOCIAL_AUTH_URL',


### PR DESCRIPTION
ACCOUNT_EMAIL_VERIFICATION = False
Отключен flow дополнительного подтверждения emai у allauth. По умолчанию доверяем email переданному провайдером.