### PR TITLE
fix/social-auth-500-3

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -240,7 +240,7 @@ SOCIALACCOUNT_ADAPTER = 'users.adapters.SocialAccountAdapter'
 SOCIALACCOUNT_QUERY_EMAIL = True  # запрашивать email у провайдера
 SOCIALACCOUNT_EMAIL_AUTHENTICATION = True  # разрешить вход по email из соцсети
 SOCIALACCOUNT_EMAIL_AUTHENTICATION_AUTO_CONNECT = True  # автоматически связывать
-ACCOUNT_EMAIL_VERIFICATION = False
+ACCOUNT_EMAIL_VERIFICATION = 'none'
 SOCIALACCOUNT_LOGIN_ON_GET = True  # сразу редиректить вход без промежуточной страницы
 FRONTEND_SOCIAL_AUTH_URL = os.getenv(
     'FRONTEND_SOCIAL_AUTH_URL',

--- a/users/urls/social_auth.py
+++ b/users/urls/social_auth.py
@@ -3,6 +3,7 @@ from django.urls import include, path
 
 from users.views import (
     redirect_social_auth_cancelled,
+    redirect_social_auth_confirm_email,
     redirect_social_auth_error,
     redirect_social_auth_signup,
 )
@@ -18,16 +19,22 @@ urlpatterns = [
     path(
         'social/login/cancelled/',
         redirect_social_auth_cancelled,
-        name='socialaccount_login_cancelled',
+        name='account_login_cancelled',
     ),
     path(
         'social/login/error/',
         redirect_social_auth_error,
-        name='socialaccount_login_error',
+        name='account_login_error',
     ),
     path(
         'social/signup/',
         redirect_social_auth_signup,
-        name='socialaccount_signup',
+        name='account_signup',
+    ),
+    # Fallback заглушка для allauth.
+    path(
+        '',
+        redirect_social_auth_confirm_email,
+        name='account_confirm_email',
     ),
 ]

--- a/users/views/__init__.py
+++ b/users/views/__init__.py
@@ -28,6 +28,7 @@ from .listener_registration import ListenerRegistrationView
 from .social_auth import (
     SocialLoginView,
     redirect_social_auth_cancelled,
+    redirect_social_auth_confirm_email,
     redirect_social_auth_error,
     redirect_social_auth_signup,
 )
@@ -56,6 +57,7 @@ __all__ = [
     'redirect_social_auth_cancelled',
     'redirect_social_auth_error',
     'redirect_social_auth_signup',
+    'redirect_social_auth_confirm_email',
     'ResendVerificationEmailView',
     'SocialLoginView',
 ]

--- a/users/views/social_auth.py
+++ b/users/views/social_auth.py
@@ -67,3 +67,8 @@ def redirect_social_auth_error(request):
 def redirect_social_auth_signup(request):
     """Редирект fallback signup social auth на фронт."""
     return _redirect_social_auth_to_frontend('signup')
+
+
+def redirect_social_auth_confirm_email(request):
+    """Редирект fallback confirm-email social auth на фронт."""
+    return _redirect_social_auth_to_frontend('confirm-email')


### PR DESCRIPTION
Исправлены имена маршрутов allauth. 
ACCOUNT_EMAIL_VERIFICATION = 'none' (было False, что не правильно)