### PR TITLE
Feat/181 genres api and tags rename

### DIFF
--- a/store/schema/album.py
+++ b/store/schema/album.py
@@ -16,10 +16,12 @@ from store.serializers import (
     AlbumWriteSerializer,
 )
 
+ALBUMS_TAGS = ['Albums']
+
 album_schema = extend_schema_view(
     list=extend_schema(
         summary='Список альбомов',
-        tags=['Album'],
+        tags=ALBUMS_TAGS,
         description='Возвращает список альбомов.',
         parameters=[
             OpenApiParameter(
@@ -74,24 +76,24 @@ album_schema = extend_schema_view(
     ),
     retrieve=extend_schema(
         summary='Получить альбом',
-        tags=['Album'],
+        tags=ALBUMS_TAGS,
         description='Возвращает альбом по id.',
     ),
     create=extend_schema(
         summary='Создать альбом',
-        tags=['Album'],
+        tags=ALBUMS_TAGS,
         description='Создаёт новый альбом.',
         responses={201: AlbumReadDetailSerializer},
     ),
     partial_update=extend_schema(
         summary='Частично обновить альбом',
-        tags=['Album'],
+        tags=ALBUMS_TAGS,
         request=AlbumWriteSerializer,
         responses={200: AlbumReadDetailSerializer},
     ),
     destroy=extend_schema(
         summary='Удалить альбом',
-        tags=['Album'],
+        tags=ALBUMS_TAGS,
         description='Удаляет альбом пользователя.',
     ),
 )

--- a/store/schema/genre.py
+++ b/store/schema/genre.py
@@ -4,44 +4,15 @@
 CRUD-операций в Swagger/ReDoc.
 """
 
-from drf_spectacular.utils import extend_schema, extend_schema_view
-
-from store.serializers import GenreSerializer
+from drf_spectacular.utils import (
+    extend_schema,
+    extend_schema_view,
+)
 
 genre_schema = extend_schema_view(
     list=extend_schema(
         summary='Список жанров',
-        description='Возвращает список всех жанров.',
+        description='Возвращает список жанров.',
         tags=['Genres'],
-    ),
-    retrieve=extend_schema(
-        summary='Получить жанр',
-        description='Возвращает жанр по id.',
-        tags=['Genres'],
-    ),
-    create=extend_schema(
-        summary='Создать жанр',
-        description='Создаёт новый жанр.',
-        tags=['Genres'],
-        request=GenreSerializer,
-        responses={201: GenreSerializer},
-    ),
-    update=extend_schema(
-        summary='Обновить жанр',
-        tags=['Genres'],
-        request=GenreSerializer,
-        responses=GenreSerializer,
-    ),
-    partial_update=extend_schema(
-        summary='Частично обновить жанр',
-        tags=['Genres'],
-        request=GenreSerializer,
-        responses=GenreSerializer,
-    ),
-    destroy=extend_schema(
-        summary='Удалить жанр',
-        description='Удаляет жанр.',
-        tags=['Genres'],
-        responses={204: None},
     ),
 )

--- a/store/schema/track.py
+++ b/store/schema/track.py
@@ -8,36 +8,38 @@ from store.serializers import (
     TrackWriteSerializer,
 )
 
+TRACKS_TAGS = ['Tracks']
+
 track_schema = extend_schema_view(
     list=extend_schema(
         summary='Список треков',
-        tags=['Track'],
+        tags=TRACKS_TAGS,
         description='Возвращает список всех аудиозаписей.',
         responses={200: TrackReadSerializer(many=True)},
     ),
     retrieve=extend_schema(
         summary='Получить трек',
-        tags=['Track'],
+        tags=TRACKS_TAGS,
         description='Возвращает детальную информацию о треке по id.',
         responses={200: TrackReadDetailSerializer},
     ),
     create=extend_schema(
         summary='Загрузить трек',
-        tags=['Track'],
+        tags=TRACKS_TAGS,
         description='Создаёт новую запись трека.',
         request=TrackWriteSerializer,
         responses={201: TrackReadDetailSerializer},
     ),
     partial_update=extend_schema(
         summary='Частично обновить трек',
-        tags=['Track'],
+        tags=TRACKS_TAGS,
         description='Обновляет только переданные поля трека.',
         request=TrackWriteSerializer,
         responses={200: TrackReadDetailSerializer},
     ),
     destroy=extend_schema(
         summary='Удалить трек',
-        tags=['Track'],
+        tags=TRACKS_TAGS,
         description='Удаляет запись трека.',
     ),
 )

--- a/store/views/genre.py
+++ b/store/views/genre.py
@@ -1,9 +1,7 @@
-"""ViewSet для работы с моделью Genre.
+"""ViewSet для работы с моделью Genre."""
 
-Предоставляет полный цикл CRUD-операций для модели Genre.
-"""
-
-from rest_framework import viewsets
+from rest_framework import mixins, viewsets
+from rest_framework.permissions import AllowAny
 
 from store.models import Genre
 from store.schema import genre_schema
@@ -11,8 +9,10 @@ from store.serializers import GenreSerializer
 
 
 @genre_schema
-class GenreViewSet(viewsets.ModelViewSet):
-    """API для работы с жанрами."""
+class GenreViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
+    """API для работы со справочником жанров."""
 
     queryset = Genre.objects.all()
+    permission_classes = (AllowAny,)
     serializer_class = GenreSerializer
+    pagination_class = None


### PR DESCRIPTION
#181 
- оставлен только endpoint GET /genres/
- удалены лишние методы (retrieve, CRUD)
- убрана пагинация
- обновлена схема документации
- переименованы теги Album и Track