### PR TITLE
ops(cicd): fix race conditions in github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,12 +1,15 @@
 name: Main Zvuchno workflow
 
+concurrency:
+  group: deploy
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
   push:
     branches:
       - main
       - develop
-      - feat/104-docker-add-healthchecks
 
 jobs:
 


### PR DESCRIPTION
Добавлен блок `concurrency` в workflow.

Чтобы предотвратить одновременный деплой нескольких коммитов. Теперь при новом пуше в `develop` старый (еще выполняющийся) процесс будет автоматически отменяться.