### PR TITLE
feat/286-catalog-api-alt-ver

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -328,3 +328,10 @@ EMAIL_HOST_PASSWORD = os.getenv('EMAIL_HOST_PASSWORD', '')
 EMAIL_USE_TLS = os.getenv('EMAIL_USE_TLS', 'True') == 'True'
 EMAIL_TIMEOUT = int(os.getenv('EMAIL_TIMEOUT', 10))
 DEFAULT_FROM_EMAIL = os.getenv('DEFAULT_FROM_EMAIL', EMAIL_HOST_USER)
+
+# Ограничение типов товаров на страницу из 16 позиций.
+CATALOG_MIX = {
+    'album': 10,
+    'carrier': 4,
+    'merch': 2,
+}

--- a/config/settings.py
+++ b/config/settings.py
@@ -335,3 +335,4 @@ CATALOG_MIX = {
     'carrier': 4,
     'merch': 2,
 }
+CARDS_PER_ROW = 4

--- a/config/settings.py
+++ b/config/settings.py
@@ -328,11 +328,3 @@ EMAIL_HOST_PASSWORD = os.getenv('EMAIL_HOST_PASSWORD', '')
 EMAIL_USE_TLS = os.getenv('EMAIL_USE_TLS', 'True') == 'True'
 EMAIL_TIMEOUT = int(os.getenv('EMAIL_TIMEOUT', 10))
 DEFAULT_FROM_EMAIL = os.getenv('DEFAULT_FROM_EMAIL', EMAIL_HOST_USER)
-
-# Ограничение типов товаров на страницу из 16 позиций.
-CATALOG_MIX = {
-    'album': 10,
-    'carrier': 4,
-    'merch': 2,
-}
-CARDS_PER_ROW = 4

--- a/store/filters/__init__.py
+++ b/store/filters/__init__.py
@@ -5,10 +5,12 @@
 
 from .album import AlbumFilter
 from .merch import MerchFilter
+from .product import ProductCatalogFilter
 from .track import TrackFilter
 
 __all__ = [
     'AlbumFilter',
     'MerchFilter',
     'TrackFilter',
+    'ProductCatalogFilter',
 ]

--- a/store/filters/product.py
+++ b/store/filters/product.py
@@ -1,0 +1,49 @@
+import django_filters
+from django.db import models
+
+from store.models import Product
+
+
+class ProductCatalogFilter(django_filters.FilterSet):
+    """Фильтры каталога товаров."""
+
+    type = django_filters.ChoiceFilter(
+        method='filter_type',
+        choices=(
+            ('all', 'Все'),
+            (Product.ProductType.ALBUM, 'Альбомы'),
+            (Product.ProductType.MERCH, 'Мерч'),
+        ),
+    )
+    genre = django_filters.CharFilter(method='filter_genre')
+
+    class Meta:
+        model = Product
+        fields = (
+            'type',
+            'genre',
+        )
+
+    def filter_type(self, queryset, name, value):
+        """Фильтрует товары по типу."""
+        if not value or value == 'all':
+            return queryset
+
+        return queryset.filter(product_type=value)
+
+    def filter_genre(self, queryset, name, value):
+        """Фильтрует товары по жанру музыкального контента."""
+        if not value:
+            return queryset
+
+        return queryset.filter(
+            models.Q(
+                product_type=Product.ProductType.ALBUM,
+                album__genre__slug=value,
+            )
+            | models.Q(
+                product_type=Product.ProductType.MERCH,
+                merch__is_carrier=True,
+                merch__album__genre__slug=value,
+            ),
+        )

--- a/store/filters/product.py
+++ b/store/filters/product.py
@@ -17,13 +17,31 @@ class ProductCatalogFilter(django_filters.FilterSet):
     )
     genre = django_filters.CharFilter(method='filter_genre')
     ordering = django_filters.CharFilter(method='filter_ordering')
+    artist = django_filters.CharFilter(method='filter_artist')
 
     class Meta:
         model = Product
         fields = (
             'type',
             'genre',
+            'artist',
             'ordering',
+        )
+
+    def filter_artist(self, queryset, name, value):
+        """Фильтрует товары по slug артиста."""
+        if not value:
+            return queryset
+
+        return queryset.filter(
+            models.Q(
+                product_type=Product.ProductType.ALBUM,
+                album__owner__artist_profile__slug=value,
+            )
+            | models.Q(
+                product_type=Product.ProductType.MERCH,
+                merch__owner__artist_profile__slug=value,
+            ),
         )
 
     def filter_ordering(self, queryset, name, value):

--- a/store/filters/product.py
+++ b/store/filters/product.py
@@ -16,13 +16,25 @@ class ProductCatalogFilter(django_filters.FilterSet):
         ),
     )
     genre = django_filters.CharFilter(method='filter_genre')
+    ordering = django_filters.CharFilter(method='filter_ordering')
 
     class Meta:
         model = Product
         fields = (
             'type',
             'genre',
+            'ordering',
         )
+
+    def filter_ordering(self, queryset, name, value):
+        """Сортирует товары каталога."""
+        if value == 'random':
+            return queryset.order_by('?')
+
+        if value == 'created_at':
+            return queryset.order_by('catalog_created_at', 'pk')
+
+        return queryset.order_by('-catalog_created_at', '-pk')
 
     def filter_type(self, queryset, name, value):
         """Фильтрует товары по типу."""

--- a/store/models/product.py
+++ b/store/models/product.py
@@ -16,6 +16,7 @@ from store.constants import (
     MAX_PRICE_DIGITS,
     MONEY_INTERNAL_PRECISION,
 )
+from store.querysets import ProductQuerySet
 
 
 class Product(models.Model):
@@ -127,6 +128,8 @@ class Product(models.Model):
     def save(self, *args, **kwargs):
         self.determine_product_type()
         super().save(*args, **kwargs)
+
+    objects = ProductQuerySet.as_manager()
 
     class Meta:
         verbose_name = 'товар'

--- a/store/querysets/__init__.py
+++ b/store/querysets/__init__.py
@@ -2,6 +2,7 @@
 
 from .cart_items import CartItemQuerySet
 from .carts import CartQuerySet
+from .product import ProductQuerySet
 from .track_visibility import TrackQuerySet
 from .visibility import VisibilityQuerySet
 
@@ -10,4 +11,5 @@ __all__ = [
     'CartItemQuerySet',
     'VisibilityQuerySet',
     'TrackQuerySet',
+    'ProductQuerySet',
 ]

--- a/store/querysets/product.py
+++ b/store/querysets/product.py
@@ -53,3 +53,19 @@ class ProductQuerySet(models.QuerySet):
         return self.annotate(
             is_favorite=Exists(favorite_variants),
         )
+
+    def with_catalog_created_at(self):
+        """Добавляет дату для сортировки каталога."""
+        return self.annotate(
+            catalog_created_at=models.Case(
+                models.When(
+                    product_type='album',
+                    then=models.F('album__created_at'),
+                ),
+                models.When(
+                    product_type='merch',
+                    then=models.F('merch__created_at'),
+                ),
+                output_field=models.DateTimeField(),
+            ),
+        )

--- a/store/querysets/product.py
+++ b/store/querysets/product.py
@@ -1,9 +1,6 @@
 from django.db import models
 from django.db.models import BooleanField, Exists, OuterRef, Value
 
-PRODUCT_TYPES = {'album', 'merch'}
-CATALOG_ALL = 'all'
-
 
 class ProductQuerySet(models.QuerySet):
     """QuerySet товаров."""
@@ -25,27 +22,15 @@ class ProductQuerySet(models.QuerySet):
             ),
         )
 
-    # def by_type(self, product_type):
-    #     """Фильтрует товары по типу."""
-    #     if not product_type or product_type == CATALOG_ALL:
-    #         return self
-    #
-    #     if product_type not in PRODUCT_TYPES:
-    #         return self.none()
-    #
-    #     return self.filter(product_type=product_type)
-
     def with_content(self):
         """Подтягивает связанные сущности товара."""
         return self.select_related(
             'album',
             'album__owner',
             'album__owner__artist_profile',
-            'album__genre',
             'merch',
             'merch__owner',
             'merch__owner__artist_profile',
-            'merch__album__genre',
             'merch__kind',
         ).prefetch_related(
             'merch__images_merch',

--- a/store/querysets/product.py
+++ b/store/querysets/product.py
@@ -1,0 +1,70 @@
+from django.db import models
+from django.db.models import BooleanField, Exists, OuterRef, Value
+
+PRODUCT_TYPES = {'album', 'merch'}
+CATALOG_ALL = 'all'
+
+
+class ProductQuerySet(models.QuerySet):
+    """QuerySet товаров."""
+
+    def visible_for_catalog(self):
+        """Возвращает товары с активным публичным контентом."""
+        return self.filter(
+            models.Q(
+                product_type='album',
+                album__is_active=True,
+                album__is_published=True,
+                album__visibility='public',
+            )
+            | models.Q(
+                product_type='merch',
+                merch__is_active=True,
+                merch__is_published=True,
+                merch__visibility='public',
+            ),
+        )
+
+    # def by_type(self, product_type):
+    #     """Фильтрует товары по типу."""
+    #     if not product_type or product_type == CATALOG_ALL:
+    #         return self
+    #
+    #     if product_type not in PRODUCT_TYPES:
+    #         return self.none()
+    #
+    #     return self.filter(product_type=product_type)
+
+    def with_content(self):
+        """Подтягивает связанные сущности товара."""
+        return self.select_related(
+            'album',
+            'album__owner',
+            'album__owner__artist_profile',
+            'album__genre',
+            'merch',
+            'merch__owner',
+            'merch__owner__artist_profile',
+            'merch__album__genre',
+            'merch__kind',
+        ).prefetch_related(
+            'merch__images_merch',
+        )
+
+    def with_is_favorite(self, user):
+        """Добавляет признак наличия варианта товара в избранном."""
+        if not user.is_authenticated:
+            return self.annotate(
+                is_favorite=Value(False, output_field=BooleanField()),
+            )
+
+        from store.models import Favorite
+
+        favorite_variants = Favorite.objects.filter(
+            user=user,
+            product_variant__product_id=OuterRef('pk'),
+        )
+
+        return self.annotate(
+            is_favorite=Exists(favorite_variants),
+        )

--- a/store/schema/__init__.py
+++ b/store/schema/__init__.py
@@ -8,6 +8,7 @@
 
 from .album import album_schema
 from .cart import cart_schema
+from .catalog import catalog_schema
 from .checkout_schema import checkout_schema
 from .delivery import delivery_schema
 from .favorites import favorites_schema
@@ -27,4 +28,5 @@ __all__ = [
     'order_schema',
     'track_schema',
     'order_schema',
+    'catalog_schema',
 ]

--- a/store/schema/catalog.py
+++ b/store/schema/catalog.py
@@ -8,8 +8,16 @@ catalog_schema = extend_schema(
     auth=[],
     summary='Список товаров каталога',
     description=(
-        'Возвращает публичный список товаров каталога. '
-        'Поддерживает фильтрацию по типу товара.'
+        'Возвращает публичный список товаров каталога.\n\n'
+        'Каталог строится от сущности Product и включает только товары, '
+        'связанные с активным, опубликованным и публичным контентом.\n\n'
+        'На текущем этапе каталог поддерживает альбомы и мерч. '
+        'Треки в списке каталога не отображаются, они доступны внутри '
+        'карточек альбомов.\n\n'
+        'Фильтр genre применяется только к музыкальному контенту: '
+        'альбомам и мерч-носителям, связанным с альбомом выбранного жанра. '
+        'Обычный мерч без связи с альбомом при фильтрации по жанру '
+        'в выдачу не попадает.'
     ),
     parameters=[
         OpenApiParameter(
@@ -19,8 +27,36 @@ catalog_schema = extend_schema(
             required=False,
             enum=['all', 'album', 'merch'],
             description=(
-                'Тип товара. all — все товары, album — альбомы, merch — мерч.'
+                'Тип товара. '
+                'all — все товары, album — только альбомы, '
+                'merch — только мерч. '
+                'Если параметр не передан, возвращаются все доступные товары.'
             ),
+        ),
+        OpenApiParameter(
+            name='genre',
+            type=OpenApiTypes.STR,
+            location=OpenApiParameter.QUERY,
+            required=False,
+            description=(
+                'Slug жанра. '
+                'Фильтрует альбомы и мерч-носители, связанные с альбомом '
+                'выбранного жанра. Обычный мерч по жанру не фильтруется.'
+            ),
+        ),
+        OpenApiParameter(
+            name='limit',
+            type=OpenApiTypes.INT,
+            location=OpenApiParameter.QUERY,
+            required=False,
+            description='Количество товаров в ответе.',
+        ),
+        OpenApiParameter(
+            name='offset',
+            type=OpenApiTypes.INT,
+            location=OpenApiParameter.QUERY,
+            required=False,
+            description='Смещение от начала списка.',
         ),
     ],
     responses=ProductCatalogListSerializer(many=True),

--- a/store/schema/catalog.py
+++ b/store/schema/catalog.py
@@ -2,9 +2,16 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 
 catalog_schema = extend_schema(
-    summary='Смешанный каталог',
+    summary='Каталог',
     tags=['Catalog'],
     parameters=[
+        OpenApiParameter(
+            name='type',
+            type=OpenApiTypes.STR,
+            enum=['all', 'album', 'carrier', 'merch'],
+            location=OpenApiParameter.QUERY,
+            description='Тип выдачи каталога.',
+        ),
         OpenApiParameter(
             name='offset',
             type=OpenApiTypes.INT,
@@ -16,7 +23,7 @@ catalog_schema = extend_schema(
             type=OpenApiTypes.STR,
             enum=['-created_at', 'created_at', 'random'],
             location=OpenApiParameter.QUERY,
-            description='Сортировка: новые, старые или случайный порядок.',
+            description='Сортировка.',
         ),
     ],
 )

--- a/store/schema/catalog.py
+++ b/store/schema/catalog.py
@@ -1,58 +1,27 @@
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 
+from store.serializers import ProductCatalogListSerializer
+
 catalog_schema = extend_schema(
-    summary='Каталог',
     tags=['Catalog'],
+    auth=[],
+    summary='Список товаров каталога',
     description=(
-        'Возвращает карточки каталога.\n\n'
-        'Без параметра type возвращает блоки для главной страницы: '
-        'albums, carriers, merch по несколько карточек каждого типа.\n\n'
-        'С параметром type возвращает плоский список карточек для ленты '
-        'или кнопки "Загрузить ещё".'
+        'Возвращает публичный список товаров каталога. '
+        'Поддерживает фильтрацию по типу товара.'
     ),
     parameters=[
         OpenApiParameter(
             name='type',
             type=OpenApiTypes.STR,
-            enum=['all', 'album', 'carrier', 'merch'],
             location=OpenApiParameter.QUERY,
             required=False,
+            enum=['all', 'album', 'merch'],
             description=(
-                'Режим выдачи каталога. '
-                'Если параметр не передан - возвращаются отдельные блоки '
-                'для главной страницы. '
-                'all - смешанная лента: альбомы, носители и мерч. '
-                'album - только альбомы. '
-                'carrier - только физические носители альбомов. '
-                'merch - только обычный мерч.'
-            ),
-        ),
-        OpenApiParameter(
-            name='offset',
-            type=OpenApiTypes.INT,
-            location=OpenApiParameter.QUERY,
-            required=False,
-            description=(
-                'Смещение для режима плоской ленты. '
-                'Используется с type=all, type=album, type=carrier '
-                'или type=merch. '
-                'Для кнопки "Загрузить ещё" фронт должен использовать URL '
-                'из поля next, а не рассчитывать offset самостоятельно.'
-            ),
-        ),
-        OpenApiParameter(
-            name='ordering',
-            type=OpenApiTypes.STR,
-            enum=['-created_at', 'created_at', 'random'],
-            location=OpenApiParameter.QUERY,
-            required=False,
-            description=(
-                'Сортировка карточек в режиме плоской ленты. '
-                '-created_at - сначала новые, используется по умолчанию. '
-                'created_at - сначала старые. '
-                'random - случайный порядок в текущей пачке.'
+                'Тип товара. all — все товары, album — альбомы, merch — мерч.'
             ),
         ),
     ],
+    responses=ProductCatalogListSerializer(many=True),
 )

--- a/store/schema/catalog.py
+++ b/store/schema/catalog.py
@@ -58,6 +58,20 @@ catalog_schema = extend_schema(
             required=False,
             description='Смещение от начала списка.',
         ),
+        OpenApiParameter(
+            name='ordering',
+            type=OpenApiTypes.STR,
+            location=OpenApiParameter.QUERY,
+            required=False,
+            enum=['-created_at', 'created_at', 'random'],
+            description=(
+                'Сортировка товаров. '
+                '-created_at — сначала новые, используется по умолчанию. '
+                'created_at — сначала старые. '
+                'random — случайная подборка для кнопки "Удиви меня"; '
+                'не предназначен для стабильной пагинации через offset.'
+            ),
+        ),
     ],
     responses=ProductCatalogListSerializer(many=True),
 )

--- a/store/schema/catalog.py
+++ b/store/schema/catalog.py
@@ -1,0 +1,22 @@
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+
+catalog_schema = extend_schema(
+    summary='Смешанный каталог',
+    tags=['Catalog'],
+    parameters=[
+        OpenApiParameter(
+            name='offset',
+            type=OpenApiTypes.INT,
+            location=OpenApiParameter.QUERY,
+            description='Смещение пачки каталога.',
+        ),
+        OpenApiParameter(
+            name='ordering',
+            type=OpenApiTypes.STR,
+            enum=['-created_at', 'created_at', 'random'],
+            location=OpenApiParameter.QUERY,
+            description='Сортировка: новые, старые или случайный порядок.',
+        ),
+    ],
+)

--- a/store/schema/catalog.py
+++ b/store/schema/catalog.py
@@ -72,6 +72,16 @@ catalog_schema = extend_schema(
                 'не предназначен для стабильной пагинации через offset.'
             ),
         ),
+        OpenApiParameter(
+            name='artist',
+            type=OpenApiTypes.STR,
+            location=OpenApiParameter.QUERY,
+            required=False,
+            description=(
+                'Slug артиста. Возвращает товары, '
+                'принадлежащие указанному артисту.'
+            ),
+        ),
     ],
     responses=ProductCatalogListSerializer(many=True),
 )

--- a/store/schema/catalog.py
+++ b/store/schema/catalog.py
@@ -4,26 +4,55 @@ from drf_spectacular.utils import OpenApiParameter, extend_schema
 catalog_schema = extend_schema(
     summary='Каталог',
     tags=['Catalog'],
+    description=(
+        'Возвращает карточки каталога.\n\n'
+        'Без параметра type возвращает блоки для главной страницы: '
+        'albums, carriers, merch по несколько карточек каждого типа.\n\n'
+        'С параметром type возвращает плоский список карточек для ленты '
+        'или кнопки "Загрузить ещё".'
+    ),
     parameters=[
         OpenApiParameter(
             name='type',
             type=OpenApiTypes.STR,
             enum=['all', 'album', 'carrier', 'merch'],
             location=OpenApiParameter.QUERY,
-            description='Тип выдачи каталога.',
+            required=False,
+            description=(
+                'Режим выдачи каталога. '
+                'Если параметр не передан - возвращаются отдельные блоки '
+                'для главной страницы. '
+                'all - смешанная лента: альбомы, носители и мерч. '
+                'album - только альбомы. '
+                'carrier - только физические носители альбомов. '
+                'merch - только обычный мерч.'
+            ),
         ),
         OpenApiParameter(
             name='offset',
             type=OpenApiTypes.INT,
             location=OpenApiParameter.QUERY,
-            description='Смещение пачки каталога.',
+            required=False,
+            description=(
+                'Смещение для режима плоской ленты. '
+                'Используется с type=all, type=album, type=carrier '
+                'или type=merch. '
+                'Для кнопки "Загрузить ещё" фронт должен использовать URL '
+                'из поля next, а не рассчитывать offset самостоятельно.'
+            ),
         ),
         OpenApiParameter(
             name='ordering',
             type=OpenApiTypes.STR,
             enum=['-created_at', 'created_at', 'random'],
             location=OpenApiParameter.QUERY,
-            description='Сортировка.',
+            required=False,
+            description=(
+                'Сортировка карточек в режиме плоской ленты. '
+                '-created_at - сначала новые, используется по умолчанию. '
+                'created_at - сначала старые. '
+                'random - случайный порядок в текущей пачке.'
+            ),
         ),
     ],
 )

--- a/store/serializers/__init__.py
+++ b/store/serializers/__init__.py
@@ -8,11 +8,7 @@ from .cart import (
     CartReadSerializer,
     CartWriteSerializer,
 )
-from .catalog import (
-    CatalogAlbumSerializer,
-    CatalogCarrierSerializer,
-    CatalogMerchSerializer,
-)
+from .catalog import ProductCatalogListSerializer
 from .checkout import CheckoutSerializer
 from .delivery import DeliverySerializer
 from .favorites import FavoritesSerializer
@@ -60,7 +56,5 @@ __all__ = [
     'TrackReadSerializer',
     'TrackReadDetailSerializer',
     'TrackWriteSerializer',
-    'CatalogAlbumSerializer',
-    'CatalogCarrierSerializer',
-    'CatalogMerchSerializer',
+    'ProductCatalogListSerializer',
 ]

--- a/store/serializers/__init__.py
+++ b/store/serializers/__init__.py
@@ -8,6 +8,11 @@ from .cart import (
     CartReadSerializer,
     CartWriteSerializer,
 )
+from .catalog import (
+    CatalogAlbumSerializer,
+    CatalogCarrierSerializer,
+    CatalogMerchSerializer,
+)
 from .checkout import CheckoutSerializer
 from .delivery import DeliverySerializer
 from .favorites import FavoritesSerializer
@@ -41,4 +46,7 @@ __all__ = [
     'TrackReadSerializer',
     'TrackReadDetailSerializer',
     'TrackWriteSerializer',
+    'CatalogAlbumSerializer',
+    'CatalogCarrierSerializer',
+    'CatalogMerchSerializer',
 ]

--- a/store/serializers/catalog.py
+++ b/store/serializers/catalog.py
@@ -43,7 +43,7 @@ class CatalogBaseSerializer(
                 None,
             )
             image = main_image or (images[0] if images else None)
-            if image:
+            if image and image.image:
                 return image.image.url
         return None
 

--- a/store/serializers/catalog.py
+++ b/store/serializers/catalog.py
@@ -1,0 +1,122 @@
+from rest_framework import serializers
+
+from store.constants import MAX_PRICE_DIGITS, MONEY_DISPLAY_PRECISION
+from store.serializers.mixins import CatalogTargetURLMixin
+
+
+class CatalogBaseSerializer(
+    CatalogTargetURLMixin,
+    serializers.Serializer,
+):
+    """Базовый сериализатор карточки смешанного каталога."""
+
+    type = serializers.CharField()
+    id = serializers.IntegerField()
+    title = serializers.CharField()
+    subtitle = serializers.CharField(allow_blank=True, required=False)
+    image = serializers.CharField(allow_null=True)
+    price = serializers.DecimalField(
+        max_digits=MAX_PRICE_DIGITS,
+        decimal_places=MONEY_DISPLAY_PRECISION,
+        allow_null=True,
+        required=False,
+    )
+    target_url = serializers.CharField()
+
+    def get_artist_name(self, owner) -> str:
+        """Возвращает имя артиста-владельца."""
+        artist = getattr(owner, 'artist_profile', None)
+        return artist.name if artist else ''
+
+    def get_image_url(self, obj) -> str | None:
+        """Возвращает URL изображения карточки."""
+        # Album
+        if hasattr(obj, 'cover_image'):
+            return obj.cover_image.url if obj.cover_image else None
+
+        # Merch
+        if hasattr(obj, 'images_merch'):
+            images = list(obj.images_merch.all())
+            main_image = next(
+                (image for image in images if image.is_main),
+                None,
+            )
+            image = main_image or (images[0] if images else None)
+            if image:
+                return image.image.url
+        return None
+
+
+class CatalogAlbumSerializer(CatalogBaseSerializer):
+    """Сериализатор альбомов для смешанного каталога."""
+
+    type = serializers.CharField(default='album')
+    title = serializers.CharField(source='name')
+    price = serializers.DecimalField(
+        source='product.price',
+        max_digits=MAX_PRICE_DIGITS,
+        decimal_places=MONEY_DISPLAY_PRECISION,
+        allow_null=True,
+    )
+    subtitle = serializers.SerializerMethodField()
+    image = serializers.SerializerMethodField()
+    target_url = serializers.SerializerMethodField()
+
+    def get_subtitle(self, obj):
+        return self.get_artist_name(obj.owner)
+
+    def get_image(self, obj):
+        return self.get_image_url(obj)
+
+    def get_target_url(self, obj):
+        return self.get_album_target_url(obj)
+
+
+class CatalogCarrierSerializer(CatalogBaseSerializer):
+    """Сериализатор носителей для смешанного каталога."""
+
+    type = serializers.CharField(default='carrier')
+    title = serializers.CharField(source='name')
+    price = serializers.DecimalField(
+        source='product.price',
+        max_digits=MAX_PRICE_DIGITS,
+        decimal_places=MONEY_DISPLAY_PRECISION,
+        allow_null=True,
+    )
+    subtitle = serializers.SerializerMethodField()
+    image = serializers.SerializerMethodField()
+    target_url = serializers.SerializerMethodField()
+
+    def get_subtitle(self, obj):
+        return self.get_artist_name(obj.owner)
+
+    def get_image(self, obj):
+        return self.get_image_url(obj)
+
+    def get_target_url(self, obj):
+        return self.get_album_target_url_by_id(obj.album_id)
+
+
+class CatalogMerchSerializer(CatalogBaseSerializer):
+    """Сериализатор мерча для смешанного каталога."""
+
+    type = serializers.CharField(default='merch')
+    title = serializers.CharField(source='name')
+    price = serializers.DecimalField(
+        source='product.price',
+        max_digits=MAX_PRICE_DIGITS,
+        decimal_places=MONEY_DISPLAY_PRECISION,
+        allow_null=True,
+    )
+    subtitle = serializers.SerializerMethodField()
+    image = serializers.SerializerMethodField()
+    target_url = serializers.SerializerMethodField()
+
+    def get_subtitle(self, obj):
+        return self.get_artist_name(obj.owner)
+
+    def get_image(self, obj):
+        return self.get_image_url(obj)
+
+    def get_target_url(self, obj):
+        return self.get_merch_target_url(obj)

--- a/store/serializers/catalog.py
+++ b/store/serializers/catalog.py
@@ -42,10 +42,14 @@ class ProductCatalogListSerializer(
         )
 
     def get_product_kind(self, obj) -> str | None:
+        """Возвращает вид товара для карточки каталога."""
         if obj.merch:
-            return obj.merch.kind.name
+            kind = getattr(obj.merch, 'kind', None)
+            return kind.name if kind else None
+
         if obj.album:
             return 'Сингл' if obj.album.is_single else 'Альбом'
+
         return None
 
     def get_artist(self, obj) -> str:

--- a/store/serializers/catalog.py
+++ b/store/serializers/catalog.py
@@ -1,126 +1,77 @@
 from rest_framework import serializers
 
 from store.constants import MAX_PRICE_DIGITS, MONEY_DISPLAY_PRECISION
+from store.models import Product
 from store.serializers.mixins import CatalogTargetURLMixin
 
 
-class CatalogBaseSerializer(
+class ProductCatalogListSerializer(
     CatalogTargetURLMixin,
-    serializers.Serializer,
+    serializers.ModelSerializer,
 ):
-    """Базовый сериализатор карточки смешанного каталога."""
+    """Сериализатор карточки товара в каталоге."""
 
-    type = serializers.CharField()
-    id = serializers.IntegerField()
-    title = serializers.CharField()
-    subtitle = serializers.CharField(allow_blank=True, required=False)
-    image = serializers.CharField(allow_null=True)
+    type = serializers.CharField(source='product_type')
+    product_kind = serializers.SerializerMethodField()
+    object_id = serializers.IntegerField(source='content_id')
+    name = serializers.CharField()
+    image = serializers.SerializerMethodField()
+    artist = serializers.SerializerMethodField()
     price = serializers.DecimalField(
         max_digits=MAX_PRICE_DIGITS,
         decimal_places=MONEY_DISPLAY_PRECISION,
         allow_null=True,
         required=False,
     )
-    target_url = serializers.CharField()
-    created_at = serializers.DateTimeField()
+    target_url = serializers.SerializerMethodField()
+    is_favorite = serializers.BooleanField(default=False)
 
-    def get_artist_name(self, owner) -> str:
+    class Meta:
+        model = Product
+        fields = (
+            'id',
+            'type',
+            'product_kind',
+            'name',
+            'object_id',
+            'image',
+            'artist',
+            'price',
+            'target_url',
+            'is_favorite',
+        )
+
+    def get_product_kind(self, obj) -> str | None:
+        if obj.merch:
+            return obj.merch.kind.name
+        if obj.album:
+            return 'Сингл' if obj.album.is_single else 'Альбом'
+        return None
+
+    def get_artist(self, obj) -> str:
         """Возвращает имя артиста-владельца."""
-        artist = getattr(owner, 'artist_profile', None)
+        artist = getattr(obj.owner, 'artist_profile', None)
         return artist.name if artist else ''
 
-    def get_image_url(self, obj) -> str | None:
+    def get_image(self, obj) -> str | None:
         """Возвращает URL изображения карточки."""
-        # Album
-        if hasattr(obj, 'cover_image'):
-            return obj.cover_image.url if obj.cover_image else None
+        content = obj.content
 
-        # Merch
-        if hasattr(obj, 'images_merch'):
-            images = list(obj.images_merch.all())
+        if content is None:
+            return None
+
+        if hasattr(content, 'cover_image') and content.cover_image:
+            return content.cover_image.url
+
+        if hasattr(content, 'images_merch'):
+            images = list(content.images_merch.all())
             main_image = next(
                 (image for image in images if image.is_main),
                 None,
             )
             image = main_image or (images[0] if images else None)
+
             if image and image.image:
                 return image.image.url
+
         return None
-
-
-class CatalogAlbumSerializer(CatalogBaseSerializer):
-    """Сериализатор альбомов для смешанного каталога."""
-
-    type = serializers.CharField(default='album')
-    title = serializers.CharField(source='name')
-    price = serializers.DecimalField(
-        source='product.price',
-        max_digits=MAX_PRICE_DIGITS,
-        decimal_places=MONEY_DISPLAY_PRECISION,
-        allow_null=True,
-    )
-    subtitle = serializers.SerializerMethodField()
-    image = serializers.SerializerMethodField()
-    target_url = serializers.SerializerMethodField()
-    created_at = serializers.DateTimeField(read_only=True)
-
-    def get_subtitle(self, obj):
-        return self.get_artist_name(obj.owner)
-
-    def get_image(self, obj):
-        return self.get_image_url(obj)
-
-    def get_target_url(self, obj):
-        return self.get_album_target_url(obj)
-
-
-class CatalogCarrierSerializer(CatalogBaseSerializer):
-    """Сериализатор носителей для смешанного каталога."""
-
-    type = serializers.CharField(default='carrier')
-    title = serializers.CharField(source='name')
-    price = serializers.DecimalField(
-        source='product.price',
-        max_digits=MAX_PRICE_DIGITS,
-        decimal_places=MONEY_DISPLAY_PRECISION,
-        allow_null=True,
-    )
-    subtitle = serializers.SerializerMethodField()
-    image = serializers.SerializerMethodField()
-    target_url = serializers.SerializerMethodField()
-    created_at = serializers.DateTimeField(read_only=True)
-
-    def get_subtitle(self, obj):
-        return self.get_artist_name(obj.owner)
-
-    def get_image(self, obj):
-        return self.get_image_url(obj)
-
-    def get_target_url(self, obj):
-        return self.get_merch_target_url(obj)
-
-
-class CatalogMerchSerializer(CatalogBaseSerializer):
-    """Сериализатор мерча для смешанного каталога."""
-
-    type = serializers.CharField(default='merch')
-    title = serializers.CharField(source='name')
-    price = serializers.DecimalField(
-        source='product.price',
-        max_digits=MAX_PRICE_DIGITS,
-        decimal_places=MONEY_DISPLAY_PRECISION,
-        allow_null=True,
-    )
-    subtitle = serializers.SerializerMethodField()
-    image = serializers.SerializerMethodField()
-    target_url = serializers.SerializerMethodField()
-    created_at = serializers.DateTimeField(read_only=True)
-
-    def get_subtitle(self, obj):
-        return self.get_artist_name(obj.owner)
-
-    def get_image(self, obj):
-        return self.get_image_url(obj)
-
-    def get_target_url(self, obj):
-        return self.get_merch_target_url(obj)

--- a/store/serializers/catalog.py
+++ b/store/serializers/catalog.py
@@ -22,6 +22,7 @@ class CatalogBaseSerializer(
         required=False,
     )
     target_url = serializers.CharField()
+    created_at = serializers.DateTimeField()
 
     def get_artist_name(self, owner) -> str:
         """Возвращает имя артиста-владельца."""
@@ -61,6 +62,7 @@ class CatalogAlbumSerializer(CatalogBaseSerializer):
     subtitle = serializers.SerializerMethodField()
     image = serializers.SerializerMethodField()
     target_url = serializers.SerializerMethodField()
+    created_at = serializers.DateTimeField(read_only=True)
 
     def get_subtitle(self, obj):
         return self.get_artist_name(obj.owner)
@@ -86,6 +88,7 @@ class CatalogCarrierSerializer(CatalogBaseSerializer):
     subtitle = serializers.SerializerMethodField()
     image = serializers.SerializerMethodField()
     target_url = serializers.SerializerMethodField()
+    created_at = serializers.DateTimeField(read_only=True)
 
     def get_subtitle(self, obj):
         return self.get_artist_name(obj.owner)
@@ -94,7 +97,7 @@ class CatalogCarrierSerializer(CatalogBaseSerializer):
         return self.get_image_url(obj)
 
     def get_target_url(self, obj):
-        return self.get_album_target_url_by_id(obj.album_id)
+        return self.get_merch_target_url(obj)
 
 
 class CatalogMerchSerializer(CatalogBaseSerializer):
@@ -111,6 +114,7 @@ class CatalogMerchSerializer(CatalogBaseSerializer):
     subtitle = serializers.SerializerMethodField()
     image = serializers.SerializerMethodField()
     target_url = serializers.SerializerMethodField()
+    created_at = serializers.DateTimeField(read_only=True)
 
     def get_subtitle(self, obj):
         return self.get_artist_name(obj.owner)

--- a/store/serializers/mixins/__init__.py
+++ b/store/serializers/mixins/__init__.py
@@ -5,10 +5,12 @@
 не зависящие от конкретной модели.
 """
 
+from .catalog_item_url_mixin import CatalogTargetURLMixin
 from .product_variant_url_mixin import ProductVariantURLMixin
 from .product_variants import ProductVariantsMixin
 
 __all__ = [
     'ProductVariantsMixin',
     'ProductVariantURLMixin',
+    'CatalogTargetURLMixin',
 ]

--- a/store/serializers/mixins/catalog_item_url_mixin.py
+++ b/store/serializers/mixins/catalog_item_url_mixin.py
@@ -1,33 +1,26 @@
 from django.urls import reverse
 
+from store.models import Product
+
 
 class CatalogTargetURLMixin:
     """Миксин для формирования ссылок каталожных карточек."""
 
-    def get_album_target_url(self, album) -> str:
+    def get_target_url(self, obj) -> str | None:
         """Возвращает ссылку на карточку альбома."""
-        return reverse(
-            'api:store:albums-detail',
-            kwargs={'pk': album.pk},
-        )
-
-    def get_album_target_url_by_id(self, album_id: int) -> str:
-        """Возвращает ссылку на карточку альбома по id."""
-        return reverse(
-            'api:store:albums-detail',
-            kwargs={'pk': album_id},
-        )
-
-    def get_merch_target_url(self, merch) -> str:
-        """Возвращает ссылку на карточку мерча."""
-        # return reverse(
-        #     'api:store:merch-detail',
-        #     kwargs={'pk': merch.pk},
-        # )
-        return 'no_link_yet'
-
-    def get_artist_url(self, artist_profile) -> str:
-        return reverse(
-            'api:users:artist_public',
-            kwargs={'slug': artist_profile.slug},
-        )
+        if obj.product_type == Product.ProductType.ALBUM:
+            return reverse(
+                'api:store:albums-detail',
+                kwargs={'pk': obj.album_id},
+            )
+        if obj.product_type == Product.ProductType.MERCH:
+            return reverse(
+                'api:store:merch-detail',
+                kwargs={'pk': obj.merch_id},
+            )
+        if obj.product_type == Product.ProductType.TRACK:
+            return reverse(
+                'api:store:tracks-detail',
+                kwargs={'pk': obj.track_id},
+            )
+        return None

--- a/store/serializers/mixins/catalog_item_url_mixin.py
+++ b/store/serializers/mixins/catalog_item_url_mixin.py
@@ -24,9 +24,7 @@ class CatalogTargetURLMixin:
         #     'api:store:merch-detail',
         #     kwargs={'pk': merch.pk},
         # )
-        return reverse(
-            f'/api/v1/store/merch/{merch.pk}/',
-        )
+        return 'no_link_yet'
 
     def get_artist_url(self, artist_profile) -> str:
         return reverse(

--- a/store/serializers/mixins/catalog_item_url_mixin.py
+++ b/store/serializers/mixins/catalog_item_url_mixin.py
@@ -1,26 +1,19 @@
 from django.urls import reverse
 
-from store.models import Product
-
 
 class CatalogTargetURLMixin:
     """Миксин для формирования ссылок каталожных карточек."""
 
     def get_target_url(self, obj) -> str | None:
         """Возвращает ссылку на карточку альбома."""
-        if obj.product_type == Product.ProductType.ALBUM:
+        if obj.product_type == 'album':
             return reverse(
                 'api:store:albums-detail',
                 kwargs={'pk': obj.album_id},
             )
-        if obj.product_type == Product.ProductType.MERCH:
+        if obj.product_type == 'merch':
             return reverse(
                 'api:store:merch-detail',
                 kwargs={'pk': obj.merch_id},
-            )
-        if obj.product_type == Product.ProductType.TRACK:
-            return reverse(
-                'api:store:tracks-detail',
-                kwargs={'pk': obj.track_id},
             )
         return None

--- a/store/serializers/mixins/catalog_item_url_mixin.py
+++ b/store/serializers/mixins/catalog_item_url_mixin.py
@@ -1,0 +1,35 @@
+from django.urls import reverse
+
+
+class CatalogTargetURLMixin:
+    """Миксин для формирования ссылок каталожных карточек."""
+
+    def get_album_target_url(self, album) -> str:
+        """Возвращает ссылку на карточку альбома."""
+        return reverse(
+            'api:store:albums-detail',
+            kwargs={'pk': album.pk},
+        )
+
+    def get_album_target_url_by_id(self, album_id: int) -> str:
+        """Возвращает ссылку на карточку альбома по id."""
+        return reverse(
+            'api:store:albums-detail',
+            kwargs={'pk': album_id},
+        )
+
+    def get_merch_target_url(self, merch) -> str:
+        """Возвращает ссылку на карточку мерча."""
+        # return reverse(
+        #     'api:store:merch-detail',
+        #     kwargs={'pk': merch.pk},
+        # )
+        return reverse(
+            f'/api/v1/store/merch/{merch.pk}/',
+        )
+
+    def get_artist_url(self, artist_profile) -> str:
+        return reverse(
+            'api:users:artist_public',
+            kwargs={'slug': artist_profile.slug},
+        )

--- a/store/urls.py
+++ b/store/urls.py
@@ -14,9 +14,9 @@ from .views import (
     GenreViewSet,
     MerchViewSet,
     OrderViewSet,
+    ProductCatalogListView,
     TrackViewSet,
 )
-from .views.catalog import CatalogView
 
 app_name = 'store'
 
@@ -32,5 +32,5 @@ router.register(r'orders', OrderViewSet, basename='orders')
 
 urlpatterns = [
     path('', include(router.urls)),
-    path('catalog/', CatalogView.as_view(), name='catalog'),
+    path('catalog/', ProductCatalogListView.as_view(), name='catalog'),
 ]

--- a/store/urls.py
+++ b/store/urls.py
@@ -15,6 +15,7 @@ from .views import (
     OrderViewSet,
     TrackViewSet,
 )
+from .views.catalog import CatalogView
 
 app_name = 'store'
 
@@ -29,4 +30,5 @@ router.register(r'orders', OrderViewSet, basename='orders')
 
 urlpatterns = [
     path('', include(router.urls)),
+    path('catalog/', CatalogView.as_view(), name='catalog'),
 ]

--- a/store/views/__init__.py
+++ b/store/views/__init__.py
@@ -1,6 +1,6 @@
 from .album import AlbumViewSet
 from .cart import CartViewSet
-from .catalog import CatalogView
+from .catalog import ProductCatalogListView
 from .delivery import DeliveryViewSet
 from .favorites import FavoritesViewSet
 from .genre import GenreViewSet
@@ -19,5 +19,5 @@ __all__ = [
     'MerchViewSet',
     'OrderViewSet',
     'TrackViewSet',
-    'CatalogView',
+    'ProductCatalogListView',
 ]

--- a/store/views/__init__.py
+++ b/store/views/__init__.py
@@ -1,5 +1,6 @@
 from .album import AlbumViewSet
 from .cart import CartViewSet
+from .catalog import CatalogView
 from .delivery import DeliveryViewSet
 from .favorites import FavoritesViewSet
 from .genre import GenreViewSet
@@ -16,4 +17,5 @@ __all__ = [
     'GenreViewSet',
     'OrderViewSet',
     'TrackViewSet',
+    'CatalogView',
 ]

--- a/store/views/catalog.py
+++ b/store/views/catalog.py
@@ -18,8 +18,9 @@ class ProductCatalogListView(ListAPIView):
     filterset_class = ProductCatalogFilter
 
     def get_queryset(self):
-        queryset = Product.objects.visible_for_catalog().with_content()
-        if self.request.user.is_authenticated:
-            queryset = queryset.with_is_favorite(user=self.request.user)
-
-        return queryset
+        return (
+            Product.objects
+            .visible_for_catalog()
+            .with_content()
+            .with_is_favorite(user=self.request.user)
+        )

--- a/store/views/catalog.py
+++ b/store/views/catalog.py
@@ -1,0 +1,5 @@
+from rest_framework.views import APIView
+
+
+class CatalogView(APIView):
+    """Представление каталога."""

--- a/store/views/catalog.py
+++ b/store/views/catalog.py
@@ -1,5 +1,181 @@
+import random
+from itertools import chain
+
+from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from config import settings
+from store.models import Album, Merch
+from store.schema import catalog_schema
+from store.serializers import (
+    CatalogAlbumSerializer,
+    CatalogCarrierSerializer,
+    CatalogMerchSerializer,
+)
 
+
+@catalog_schema
 class CatalogView(APIView):
     """Представление каталога."""
+
+    default_limit: int = sum(settings.CATALOG_MIX.values())
+    allowed_ordering = ('created_at', '-created_at', 'random')
+
+    def get(self, request):
+        """Возвращает смешанный список карточек каталога."""
+        offset = self._get_offset()
+        batch_number = offset // self.default_limit
+
+        items = self._get_catalog_items(batch_number)
+        items = self._sort_items(items)
+
+        return Response(
+            {
+                'next': self._get_next_url(offset, len(items)),
+                'results': items,
+            },
+        )
+
+    def _get_catalog_items(self, batch_number: int) -> list[dict]:
+        """Возвращает общий список карточек каталога."""
+        albums = self._get_album_items(
+            limit=settings.CATALOG_MIX['album'],
+            batch_number=batch_number,
+        )
+        carriers = self._get_carrier_items(
+            limit=settings.CATALOG_MIX['carrier'],
+            batch_number=batch_number,
+        )
+        merch = self._get_merch_items(
+            limit=settings.CATALOG_MIX['merch'],
+            batch_number=batch_number,
+        )
+
+        return list(chain(albums, carriers, merch))
+
+    def _get_album_items(
+        self,
+        limit: int,
+        batch_number: int,
+    ) -> list[dict]:
+        """Возвращает карточки альбомов."""
+        start, stop = self._get_bounds(limit, batch_number)
+
+        albums = (
+            Album.objects
+            .visible_for(self.request.user, 'list')
+            .select_related('owner', 'owner__artist_profile', 'product')
+            .order_by('-created_at')[start:stop]
+        )
+
+        return CatalogAlbumSerializer(
+            albums,
+            many=True,
+            context=self.get_serializer_context(),
+        ).data
+
+    def _get_carrier_items(
+        self,
+        limit: int,
+        batch_number: int,
+    ) -> list[dict]:
+        """Возвращает карточки носителей."""
+        start, stop = self._get_bounds(limit, batch_number)
+
+        carriers = (
+            Merch.objects
+            # .visible_for(self.request.user, 'list')
+            .filter(is_carrier=True, album__isnull=False)
+            .select_related(
+                'owner',
+                'owner__artist_profile',
+                'album',
+                'product',
+            )
+            .prefetch_related('images_merch')
+            .order_by('-created_at')[start:stop]
+        )
+
+        return CatalogCarrierSerializer(
+            carriers,
+            many=True,
+            context=self.get_serializer_context(),
+        ).data
+
+    def _get_merch_items(
+        self,
+        limit: int,
+        batch_number: int,
+    ) -> list[dict]:
+        """Возвращает карточки обычного мерча."""
+        start, stop = self._get_bounds(limit, batch_number)
+
+        merch = (
+            Merch.objects
+            # .visible_for(self.request.user, 'list')
+            .filter(is_carrier=False)
+            .select_related('owner', 'owner__artist_profile', 'product')
+            .prefetch_related('images_merch')
+            .order_by('-created_at')[start:stop]
+        )
+
+        return CatalogMerchSerializer(
+            merch,
+            many=True,
+            context=self.get_serializer_context(),
+        ).data
+
+    def _get_bounds(
+        self,
+        limit: int,
+        batch_number: int,
+    ) -> tuple[int, int]:
+        """Возвращает границы среза для типа карточек."""
+        start = batch_number * limit
+        stop = start + limit
+        return start, stop
+
+    def _get_offset(self) -> int:
+        """Возвращает offset из query params."""
+        raw_offset = self.request.query_params.get('offset', 0)
+
+        try:
+            offset = int(raw_offset)
+        except (TypeError, ValueError):
+            return 0
+
+        if offset < 0:
+            return 0
+
+        return offset // self.default_limit * self.default_limit
+
+    def _get_next_url(self, offset: int, page_size: int) -> str | None:
+        """Возвращает URL следующей порции каталога."""
+        if page_size == 0:
+            return None
+
+        params = self.request.query_params.copy()
+        params['offset'] = offset + self.default_limit
+
+        return f'{self.request.path}?{params.urlencode()}'
+
+    def get_serializer_context(self) -> dict:
+        """Возвращает контекст сериализатора."""
+        return {'request': self.request}
+
+    def _sort_items(self, items: list[dict]) -> list[dict]:
+        """Сортирует карточки каталога."""
+        ordering = self.request.query_params.get('ordering', '-created_at')
+
+        if ordering not in self.allowed_ordering:
+            ordering = '-created_at'
+
+        if ordering == 'random':
+            random.shuffle(items)
+            return items
+
+        return sorted(
+            items,
+            key=lambda item: item['created_at'],
+            reverse=ordering == '-created_at',
+        )

--- a/store/views/catalog.py
+++ b/store/views/catalog.py
@@ -1,6 +1,7 @@
 import random
 from itertools import chain
 
+from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -20,21 +21,50 @@ class CatalogView(APIView):
 
     default_limit: int = sum(settings.CATALOG_MIX.values())
     allowed_ordering = ('created_at', '-created_at', 'random')
+    allowed_types = ('all', 'album', 'carrier', 'merch', None)
 
     def get(self, request):
-        """Возвращает смешанный список карточек каталога."""
+        """Возвращает карточки каталога."""
+        catalog_type = request.query_params.get('type')
+
+        if catalog_type is None:
+            return self._get_homepage_response()
+
+        if catalog_type not in self.allowed_types:
+            return Response(
+                {'type': 'Недопустимый тип каталога.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         offset = self._get_offset()
         batch_number = offset // self.default_limit
 
-        items = self._get_catalog_items(batch_number)
+        items = self._get_items_by_type(catalog_type, batch_number)
         items = self._sort_items(items)
 
-        return Response(
-            {
-                'next': self._get_next_url(offset, len(items)),
-                'results': items,
-            },
-        )
+        return Response({
+            'next': self._get_next_url(offset, len(items)),
+            'results': items,
+        })
+
+    def _get_items_by_type(
+        self,
+        catalog_type: str,
+        batch_number: int,
+    ) -> list[dict]:
+        """Возвращает карточки каталога по типу."""
+        if catalog_type == 'all':
+            return self._get_catalog_items(batch_number)
+
+        limit = self.default_limit
+
+        if catalog_type == 'album':
+            return self._get_album_items(limit, batch_number)
+
+        if catalog_type == 'carrier':
+            return self._get_carrier_items(limit, batch_number)
+
+        return self._get_merch_items(limit, batch_number)
 
     def _get_catalog_items(self, batch_number: int) -> list[dict]:
         """Возвращает общий список карточек каталога."""
@@ -179,3 +209,23 @@ class CatalogView(APIView):
             key=lambda item: item['created_at'],
             reverse=ordering == '-created_at',
         )
+
+    def _get_homepage_response(self) -> Response:
+        """Возвращает блоки главной страницы каталога."""
+        batch_number = 0
+        preview_limit = settings.CARDS_PER_ROW
+
+        return Response({
+            'albums': self._get_album_items(
+                preview_limit,
+                batch_number,
+            ),
+            'carriers': self._get_carrier_items(
+                preview_limit,
+                batch_number,
+            ),
+            'merch': self._get_merch_items(
+                preview_limit,
+                batch_number,
+            ),
+        })

--- a/store/views/catalog.py
+++ b/store/views/catalog.py
@@ -1,231 +1,25 @@
-import random
-from itertools import chain
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework.generics import ListAPIView
+from rest_framework.permissions import AllowAny
 
-from rest_framework import status
-from rest_framework.response import Response
-from rest_framework.views import APIView
-
-from config import settings
-from store.models import Album, Merch
+from store.filters import ProductCatalogFilter
+from store.models import Product
 from store.schema import catalog_schema
-from store.serializers import (
-    CatalogAlbumSerializer,
-    CatalogCarrierSerializer,
-    CatalogMerchSerializer,
-)
+from store.serializers import ProductCatalogListSerializer
 
 
 @catalog_schema
-class CatalogView(APIView):
-    """Представление каталога."""
+class ProductCatalogListView(ListAPIView):
+    """Список товаров каталога."""
 
-    default_limit: int = sum(settings.CATALOG_MIX.values())
-    allowed_ordering = ('created_at', '-created_at', 'random')
-    allowed_types = ('all', 'album', 'carrier', 'merch', None)
+    serializer_class = ProductCatalogListSerializer
+    permission_classes = (AllowAny,)
+    filter_backends = (DjangoFilterBackend,)
+    filterset_class = ProductCatalogFilter
 
-    def get(self, request):
-        """Возвращает карточки каталога."""
-        catalog_type = request.query_params.get('type')
+    def get_queryset(self):
+        queryset = Product.objects.visible_for_catalog().with_content()
+        if self.request.user.is_authenticated:
+            queryset = queryset.with_is_favorite(user=self.request.user)
 
-        if catalog_type is None:
-            return self._get_homepage_response()
-
-        if catalog_type not in self.allowed_types:
-            return Response(
-                {'type': 'Недопустимый тип каталога.'},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        offset = self._get_offset()
-        batch_number = offset // self.default_limit
-
-        items = self._get_items_by_type(catalog_type, batch_number)
-        items = self._sort_items(items)
-
-        return Response({
-            'next': self._get_next_url(offset, len(items)),
-            'results': items,
-        })
-
-    def _get_items_by_type(
-        self,
-        catalog_type: str,
-        batch_number: int,
-    ) -> list[dict]:
-        """Возвращает карточки каталога по типу."""
-        if catalog_type == 'all':
-            return self._get_catalog_items(batch_number)
-
-        limit = self.default_limit
-
-        if catalog_type == 'album':
-            return self._get_album_items(limit, batch_number)
-
-        if catalog_type == 'carrier':
-            return self._get_carrier_items(limit, batch_number)
-
-        return self._get_merch_items(limit, batch_number)
-
-    def _get_catalog_items(self, batch_number: int) -> list[dict]:
-        """Возвращает общий список карточек каталога."""
-        albums = self._get_album_items(
-            limit=settings.CATALOG_MIX['album'],
-            batch_number=batch_number,
-        )
-        carriers = self._get_carrier_items(
-            limit=settings.CATALOG_MIX['carrier'],
-            batch_number=batch_number,
-        )
-        merch = self._get_merch_items(
-            limit=settings.CATALOG_MIX['merch'],
-            batch_number=batch_number,
-        )
-
-        return list(chain(albums, carriers, merch))
-
-    def _get_album_items(
-        self,
-        limit: int,
-        batch_number: int,
-    ) -> list[dict]:
-        """Возвращает карточки альбомов."""
-        start, stop = self._get_bounds(limit, batch_number)
-
-        albums = (
-            Album.objects
-            .visible_for(self.request.user, 'list')
-            .select_related('owner', 'owner__artist_profile', 'product')
-            .order_by('-created_at')[start:stop]
-        )
-
-        return CatalogAlbumSerializer(
-            albums,
-            many=True,
-            context=self.get_serializer_context(),
-        ).data
-
-    def _get_carrier_items(
-        self,
-        limit: int,
-        batch_number: int,
-    ) -> list[dict]:
-        """Возвращает карточки носителей."""
-        start, stop = self._get_bounds(limit, batch_number)
-
-        carriers = (
-            Merch.objects
-            # .visible_for(self.request.user, 'list')
-            .filter(is_carrier=True, album__isnull=False)
-            .select_related(
-                'owner',
-                'owner__artist_profile',
-                'album',
-                'product',
-            )
-            .prefetch_related('images_merch')
-            .order_by('-created_at')[start:stop]
-        )
-
-        return CatalogCarrierSerializer(
-            carriers,
-            many=True,
-            context=self.get_serializer_context(),
-        ).data
-
-    def _get_merch_items(
-        self,
-        limit: int,
-        batch_number: int,
-    ) -> list[dict]:
-        """Возвращает карточки обычного мерча."""
-        start, stop = self._get_bounds(limit, batch_number)
-
-        merch = (
-            Merch.objects
-            # .visible_for(self.request.user, 'list')
-            .filter(is_carrier=False)
-            .select_related('owner', 'owner__artist_profile', 'product')
-            .prefetch_related('images_merch')
-            .order_by('-created_at')[start:stop]
-        )
-
-        return CatalogMerchSerializer(
-            merch,
-            many=True,
-            context=self.get_serializer_context(),
-        ).data
-
-    def _get_bounds(
-        self,
-        limit: int,
-        batch_number: int,
-    ) -> tuple[int, int]:
-        """Возвращает границы среза для типа карточек."""
-        start = batch_number * limit
-        stop = start + limit
-        return start, stop
-
-    def _get_offset(self) -> int:
-        """Возвращает offset из query params."""
-        raw_offset = self.request.query_params.get('offset', 0)
-
-        try:
-            offset = int(raw_offset)
-        except (TypeError, ValueError):
-            return 0
-
-        if offset < 0:
-            return 0
-
-        return offset // self.default_limit * self.default_limit
-
-    def _get_next_url(self, offset: int, page_size: int) -> str | None:
-        """Возвращает URL следующей порции каталога."""
-        if page_size == 0:
-            return None
-
-        params = self.request.query_params.copy()
-        params['offset'] = offset + self.default_limit
-
-        return f'{self.request.path}?{params.urlencode()}'
-
-    def get_serializer_context(self) -> dict:
-        """Возвращает контекст сериализатора."""
-        return {'request': self.request}
-
-    def _sort_items(self, items: list[dict]) -> list[dict]:
-        """Сортирует карточки каталога."""
-        ordering = self.request.query_params.get('ordering', '-created_at')
-
-        if ordering not in self.allowed_ordering:
-            ordering = '-created_at'
-
-        if ordering == 'random':
-            random.shuffle(items)
-            return items
-
-        return sorted(
-            items,
-            key=lambda item: item['created_at'],
-            reverse=ordering == '-created_at',
-        )
-
-    def _get_homepage_response(self) -> Response:
-        """Возвращает блоки главной страницы каталога."""
-        batch_number = 0
-        preview_limit = settings.CARDS_PER_ROW
-
-        return Response({
-            'albums': self._get_album_items(
-                preview_limit,
-                batch_number,
-            ),
-            'carriers': self._get_carrier_items(
-                preview_limit,
-                batch_number,
-            ),
-            'merch': self._get_merch_items(
-                preview_limit,
-                batch_number,
-            ),
-        })
+        return queryset

--- a/store/views/catalog.py
+++ b/store/views/catalog.py
@@ -23,4 +23,5 @@ class ProductCatalogListView(ListAPIView):
             .visible_for_catalog()
             .with_content()
             .with_is_favorite(user=self.request.user)
+            .with_catalog_created_at()
         )


### PR DESCRIPTION
Альтернативная реализация каталога (переосмысление feat/286-catalog-api-type-all)
/api/v1/store/catalog/
Переделан api каталога - завязан на модель Product.

По списку полей надо достичь соглашения.

- выдача публичных товаров каталога;
- поддержка типов all, album, merch;
- фильтр по жанру для альбомов и мерчей-носителей, связанных с альбомом;
- сортировка по дате создания контента;
- режим ordering=random для кнопки «Удиви меня»;
- флаг `is_favorite`, если у пользователя в избранном есть хотя бы один вариант товара;
- единый формат карточки каталога.