### PR TITLE
fix/342-artist-image-to-catalog-detail

### DIFF
--- a/store/serializers/catalog_detail.py
+++ b/store/serializers/catalog_detail.py
@@ -11,10 +11,11 @@ from store.serializers.merch import MerchDetailSerializer
 from store.serializers.mixins import ProductImagesMixin
 
 
-class CatalogDetailBaseSerializer(serializers.Serializer):
+class CatalogDetailBaseSerializer(ProductImagesMixin, serializers.Serializer):
     """Базовый сериализатор витринной detail-карточки."""
 
     artist_name = serializers.SerializerMethodField()
+    artist_image = serializers.SerializerMethodField()
 
     def get_artist_name(self, obj) -> str | None:
         """Возвращает имя артиста-владельца."""
@@ -22,6 +23,13 @@ class CatalogDetailBaseSerializer(serializers.Serializer):
         if artist is None:
             return None
         return artist.name
+
+    def get_artist_image(self, obj) -> str | None:
+        """Возвращает изображение артиста."""
+        artist = getattr(obj.owner, 'artist_profile', None)
+        if artist is None:
+            return None
+        return self.get_image_url(artist.cover)
 
 
 class CatalogReleaseVariantSerializer(
@@ -133,7 +141,6 @@ class CatalogReleaseVariantSerializer(
 
 
 class CatalogReleaseDetailSerializer(
-    ProductImagesMixin,
     CatalogDetailBaseSerializer,
     serializers.ModelSerializer,
 ):
@@ -148,6 +155,7 @@ class CatalogReleaseDetailSerializer(
         fields = (
             'id',
             'artist_name',
+            'artist_image',
             'is_single',
             'variants',
         )
@@ -180,8 +188,18 @@ class CatalogMerchDetailSerializer(
 ):
     """Вариант обычного мерча в витринной detail странице."""
 
+    price = serializers.DecimalField(
+        source='product.price',
+        max_digits=MAX_PRICE_DIGITS,
+        decimal_places=MONEY_DISPLAY_PRECISION,
+        read_only=True,
+    )
+
     class Meta(MerchDetailSerializer.Meta):
-        fields = MerchDetailSerializer.Meta.fields + ('artist_name',)
+        fields = MerchDetailSerializer.Meta.fields + (
+            'artist_name',
+            'artist_image',
+        )
 
     def to_representation(self, instance):
         data = super().to_representation(instance)

--- a/store/tests/assertions.py
+++ b/store/tests/assertions.py
@@ -1,7 +1,5 @@
 """Проверки контрактов API приложения store."""
 
-from decimal import Decimal
-
 PUBLIC_PRODUCT_CARD_KEYS = {
     'product_id',
     'name',
@@ -23,6 +21,7 @@ PUBLIC_PRODUCT_CARD_TARGET_KEYS = {
 CATALOG_RELEASE_DETAIL_KEYS = {
     'id',
     'artist_name',
+    'artist_image',
     'is_single',
     'variants',
 }
@@ -57,6 +56,7 @@ CATALOG_MERCH_DETAIL_KEYS = {
     'stock',
     'variants',
     'artist_name',
+    'artist_image',
     'images',
 }
 
@@ -86,7 +86,7 @@ def assert_public_product_card_contract(card):
     assert isinstance(card['year'], int) or card['year'] is None
     assert isinstance(card['price'], str)
     assert isinstance(card['is_favorite'], bool)
-
+    assert card['image'] is None or isinstance(card['image'], str)
     assert isinstance(card['target']['type'], str)
     assert isinstance(card['target']['url'], str)
     assert (
@@ -101,6 +101,10 @@ def assert_catalog_release_detail_contract(data):
 
     assert isinstance(data['id'], int)
     assert isinstance(data['artist_name'], str)
+    assert data['artist_image'] is None or isinstance(
+        data['artist_image'],
+        str,
+    )
     assert isinstance(data['is_single'], bool)
     assert isinstance(data['variants'], list)
 
@@ -130,12 +134,16 @@ def assert_catalog_merch_detail_contract(data):
     assert isinstance(data['id'], int)
     assert isinstance(data['name'], str)
     assert isinstance(data['description'], str)
-    assert isinstance(data['price'], Decimal)
+    assert isinstance(data['price'], str)
     assert isinstance(data['allow_overpay'], bool)
     assert isinstance(data['kind'], str)
     assert isinstance(data['property_name'], str)
     assert data['stock'] is None or isinstance(data['stock'], int)
     assert data['artist_name'] is None or isinstance(data['artist_name'], str)
+    assert data['artist_image'] is None or isinstance(
+        data['artist_image'],
+        str,
+    )
     assert isinstance(data['images'], list)
     assert isinstance(data['variants'], list)
 

--- a/store/tests/test_catalog_detail_api.py
+++ b/store/tests/test_catalog_detail_api.py
@@ -125,7 +125,7 @@ class TestCatalogMerchDetail:
         assert response.data['id'] == merch.id
         assert response.data['name'] == merch.name
         assert response.data['description'] == merch.description
-        assert response.data['price'] == float(product.price)
+        assert response.data['price'] == str(product.price)
         assert response.data['allow_overpay'] == product.allow_overpay
         assert response.data['kind'] == kind.name
         assert response.data['property_name'] == product.property_name


### PR DESCRIPTION
Добавлено изображение артиста в ответ каталожного детального представления релиза и мерча.
Цена приведена к одному виду у мерча и релиза.
Поправлены тесты.