### PR TITLE
fix/397-carrier-with-no-album

### DIFF
--- a/store/views/catalog.py
+++ b/store/views/catalog.py
@@ -191,7 +191,8 @@ class CatalogMerchDetailView(MerchViewSet):
         return (
             super()
             .get_queryset()
-            .filter(
-                kind__is_carrier=False,
+            .exclude(
+                kind__is_carrier=True,
+                album__isnull=False,
             )
         )


### PR DESCRIPTION
детальный эндпоинт мерча теперь допускает носители без альбома.