### PR TITLE
feat/388-player-api

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,7 +138,7 @@ services:
     env_file: .env
     volumes:
       - static:/staticfiles
-      - media:/media/
+      - ./media:/media:ro
     depends_on:
       - backend
     ports:

--- a/store/schema/__init__.py
+++ b/store/schema/__init__.py
@@ -25,6 +25,10 @@ from .genre import genre_schema
 from .merch import merch_schema
 from .merch_kind import merch_kinds_schema
 from .order import order_schema
+from .player import (
+    player_album_schema,
+    player_track_play_schema,
+)
 from .promocode import promocode_schema
 from .purchased_music import (
     archive_download_link_schema,
@@ -53,6 +57,8 @@ __all__ = [
     'merch_kinds_schema',
     'merch_schema',
     'order_schema',
+    'player_album_schema',
+    'player_track_play_schema',
     'promocode_schema',
     'purchased_music_download_detail_schema',
     'purchased_music_schema',

--- a/store/schema/player.py
+++ b/store/schema/player.py
@@ -1,0 +1,62 @@
+"""Схемы OpenAPI для API плеера."""
+
+from drf_spectacular.utils import OpenApiResponse, extend_schema
+from rest_framework import status
+
+from store.serializers import (
+    PlaybackNotReadySerializer,
+    PlayerAlbumSerializer,
+)
+
+PLAYER_TAGS = ['Player']
+
+
+player_album_schema = extend_schema(
+    summary='Получить очередь воспроизведения релиза',
+    description=(
+        'Возвращает альбом и доступные для текущего пользователя треки '
+        'в порядке их позиции. '
+        'Каждый трек содержит товарные данные и объект playback. '
+        'Поле playback.duration показывает длительность фактически '
+        'доступного источника, которая может отличаться от полной '
+        'длительности трека.'
+    ),
+    tags=PLAYER_TAGS,
+    auth=[],
+    responses={
+        status.HTTP_200_OK: PlayerAlbumSerializer,
+        status.HTTP_404_NOT_FOUND: OpenApiResponse(
+            description='Релиз не найден или недоступен.',
+        ),
+    },
+)
+
+
+player_track_play_schema = extend_schema(
+    summary='Запустить воспроизведение трека',
+    description=(
+        'Проверяет доступность трека и перенаправляет браузер на '
+        'подходящий источник аудио. '
+        'Сейчас доступно публичное preview; позднее endpoint сможет '
+        'выбирать полный stream для пользователя с правом доступа. '
+        'Клиенту следует передавать этот URL непосредственно в src '
+        'элемента audio и позволить браузеру обработать redirect.'
+    ),
+    tags=PLAYER_TAGS,
+    auth=[],
+    responses={
+        status.HTTP_302_FOUND: OpenApiResponse(
+            description=(
+                'Перенаправление на аудиофайл. '
+                'Адрес источника передаётся в заголовке Location.'
+            ),
+        ),
+        status.HTTP_404_NOT_FOUND: OpenApiResponse(
+            description=(
+                'Трек не найден, недоступен или preview временно '
+                'не содержит готового файла.'
+            ),
+        ),
+        status.HTTP_409_CONFLICT: PlaybackNotReadySerializer,
+    },
+)

--- a/store/serializers/__init__.py
+++ b/store/serializers/__init__.py
@@ -33,6 +33,11 @@ from .merch import (
 )
 from .merch_kind import MerchKindSerializer
 from .order import OrderDetailSerializer, OrderItemSerializer, OrderSerializer
+from .player import (
+    PlayerAlbumSerializer,
+    PlayerAlbumTrackSerializer,
+    TrackPlaybackSerializer,
+)
 from .promocode import (
     PromocodeReadDetailSerializer,
     PromocodeReadSerializer,
@@ -83,6 +88,9 @@ __all__ = [
     'OrderDetailSerializer',
     'OrderItemSerializer',
     'OrderSerializer',
+    'PlayerAlbumSerializer',
+    'PlayerAlbumTrackSerializer',
+    'TrackPlaybackSerializer',
     'PromocodeReadDetailSerializer',
     'PromocodeReadSerializer',
     'PromocodeWriteSerializer',

--- a/store/serializers/__init__.py
+++ b/store/serializers/__init__.py
@@ -34,6 +34,7 @@ from .merch import (
 from .merch_kind import MerchKindSerializer
 from .order import OrderDetailSerializer, OrderItemSerializer, OrderSerializer
 from .player import (
+    PlaybackNotReadySerializer,
     PlayerAlbumSerializer,
     PlayerAlbumTrackSerializer,
     TrackPlaybackSerializer,
@@ -88,6 +89,7 @@ __all__ = [
     'OrderDetailSerializer',
     'OrderItemSerializer',
     'OrderSerializer',
+    'PlaybackNotReadySerializer',
     'PlayerAlbumSerializer',
     'PlayerAlbumTrackSerializer',
     'TrackPlaybackSerializer',

--- a/store/serializers/player.py
+++ b/store/serializers/player.py
@@ -1,0 +1,114 @@
+"""Сериализаторы данных для плеера."""
+
+from rest_framework import serializers
+from rest_framework.reverse import reverse
+
+from .track import TrackReadSerializer
+from store.models import Album, TrackGeneratedAudio
+
+
+class TrackPlaybackSerializer(serializers.Serializer):
+    """Данные доступного источника воспроизведения трека."""
+
+    status = serializers.ChoiceField(
+        choices=TrackGeneratedAudio.ProcessingStatus.choices,
+        read_only=True,
+    )
+    kind = serializers.ChoiceField(
+        choices=(
+            ('preview', 'Превью'),
+            ('full', 'Полная версия'),
+        ),
+        allow_null=True,
+        read_only=True,
+    )
+    duration = serializers.IntegerField(
+        allow_null=True,
+        min_value=1,
+        read_only=True,
+    )
+    url = serializers.CharField(
+        allow_null=True,
+        read_only=True,
+    )
+
+    def to_representation(self, instance):
+        """Возвращает данные источника воспроизведения трека."""
+        generated = getattr(instance, 'generated', None)
+
+        if generated is None:
+            return self._not_ready(
+                TrackGeneratedAudio.ProcessingStatus.PENDING,
+            )
+
+        if generated.preview_status != (
+            TrackGeneratedAudio.ProcessingStatus.READY
+        ):
+            return self._not_ready(generated.preview_status)
+
+        if not generated.preview_file or not generated.preview_duration:
+            return self._not_ready(
+                TrackGeneratedAudio.ProcessingStatus.FAILED,
+            )
+
+        return {
+            'status': TrackGeneratedAudio.ProcessingStatus.READY,
+            'kind': 'preview',
+            'duration': generated.preview_duration,
+            'url': reverse(
+                'api:store:player-play-track',
+                kwargs={'track_id': instance.pk},
+            ),
+        }
+
+    @staticmethod
+    def _not_ready(status: str) -> dict:
+        """Возвращает данные для неподготовленного источника."""
+        return {
+            'status': status,
+            'kind': None,
+            'duration': None,
+            'url': None,
+        }
+
+
+class PlayerAlbumTrackSerializer(TrackReadSerializer):
+    """Трек в очереди воспроизведения альбома."""
+
+    playback = TrackPlaybackSerializer(
+        source='*',
+        read_only=True,
+    )
+
+    class Meta(TrackReadSerializer.Meta):
+        fields = TrackReadSerializer.Meta.fields + ('playback',)
+
+
+class PlayerAlbumSerializer(serializers.ModelSerializer):
+    """Альбом и очередь треков для плеера."""
+
+    tracks = PlayerAlbumTrackSerializer(
+        many=True,
+        read_only=True,
+    )
+    artist_name = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Album
+        fields = (
+            'id',
+            'name',
+            'artist_name',
+            'cover_image',
+            'tracks',
+        )
+
+    @staticmethod
+    def get_artist_name(obj) -> str | None:
+        """Возвращает имя исполнителя альбома."""
+        artist = getattr(obj.owner, 'artist_profile', None)
+
+        if artist is None:
+            return None
+
+        return artist.name

--- a/store/serializers/player.py
+++ b/store/serializers/player.py
@@ -112,3 +112,15 @@ class PlayerAlbumSerializer(serializers.ModelSerializer):
             return None
 
         return artist.name
+
+
+class PlaybackNotReadySerializer(serializers.Serializer):
+    """Ошибка при недоступном для воспроизведения аудио."""
+
+    detail = serializers.CharField(
+        read_only=True,
+    )
+    status = serializers.ChoiceField(
+        choices=TrackGeneratedAudio.ProcessingStatus.choices,
+        read_only=True,
+    )

--- a/store/tests/conftest.py
+++ b/store/tests/conftest.py
@@ -283,3 +283,29 @@ def purchased_music_archive_download_link_url():
         )
 
     return _url
+
+
+@pytest.fixture
+def player_album_url():
+    """Возвращает URL очереди альбома для плеера."""
+
+    def build(album_id: int) -> str:
+        return reverse(
+            'api:store:player-album',
+            kwargs={'album_id': album_id},
+        )
+
+    return build
+
+
+@pytest.fixture
+def player_track_play_url():
+    """Возвращает URL запуска воспроизведения трека."""
+
+    def build(track_id: int) -> str:
+        return reverse(
+            'api:store:player-play-track',
+            kwargs={'track_id': track_id},
+        )
+
+    return build

--- a/store/tests/test_player_api.py
+++ b/store/tests/test_player_api.py
@@ -208,17 +208,15 @@ class TestPlayerTrackPlayAPI:
 
     @staticmethod
     def create_ready_preview(track) -> TrackGeneratedAudio:
-        """Создаёт готовое preview трека."""
+        """Создаёт запись о готовом preview трека."""
         generated = TrackGeneratedAudio.objects.create(
             track=track,
             preview_status=TrackGeneratedAudio.ProcessingStatus.READY,
             preview_duration=29,
         )
-        generated.preview_file.save(
-            'preview.mp3',
-            ContentFile(b'preview-audio'),
-            save=True,
-        )
+        generated.preview_file.name = 'test/previews/preview.mp3'
+        generated.save(update_fields=('preview_file',))
+
         return generated
 
     def test_ready_preview_redirects_to_audio_file(
@@ -354,11 +352,8 @@ class TestPlayerTrackPlayAPI:
             track=track,
             preview_status=TrackGeneratedAudio.ProcessingStatus.READY,
         )
-        generated.preview_file.save(
-            'preview.mp3',
-            ContentFile(b'preview-audio'),
-            save=True,
-        )
+        generated.preview_file.name = 'test/previews/preview.mp3'
+        generated.save(update_fields=('preview_file',))
 
         response = api_client.get(
             player_track_play_url(track.id),

--- a/store/tests/test_player_api.py
+++ b/store/tests/test_player_api.py
@@ -1,0 +1,388 @@
+"""Тесты API плеера."""
+
+from decimal import Decimal
+
+import pytest
+from django.core.files.base import ContentFile
+from rest_framework import status
+
+from store.models import Favorite, Track, TrackGeneratedAudio
+
+pytestmark = pytest.mark.django_db
+
+
+class TestPlayerAlbumAPI:
+    """Тесты получения очереди воспроизведения альбома."""
+
+    @staticmethod
+    def create_ready_preview(track) -> TrackGeneratedAudio:
+        """Создаёт готовое preview трека."""
+        generated = TrackGeneratedAudio.objects.create(
+            track=track,
+            preview_status=TrackGeneratedAudio.ProcessingStatus.READY,
+            preview_duration=29,
+        )
+        generated.preview_file.save(
+            'preview.mp3',
+            ContentFile(b'preview-audio'),
+            save=True,
+        )
+        return generated
+
+    def test_returns_album_with_tracks_in_position_order(
+        self,
+        api_client,
+        player_album_url,
+        player_track_play_url,
+        variant_factory,
+    ):
+        """Возвращает альбом и треки в порядке их позиции."""
+        first_variant = variant_factory(
+            'track',
+            name='Первый трек',
+            price=Decimal('300.00'),
+        )
+        first_track = first_variant.product.track
+        album = first_track.album
+
+        second_variant = variant_factory(
+            'track',
+            album=album,
+            name='Второй трек',
+            price=Decimal('330.00'),
+        )
+        second_track = second_variant.product.track
+
+        first_track.position = 1
+        first_track.save(update_fields=('position',))
+
+        second_track.position = 2
+        second_track.save(update_fields=('position',))
+
+        self.create_ready_preview(first_track)
+
+        TrackGeneratedAudio.objects.create(
+            track=second_track,
+            preview_status=TrackGeneratedAudio.ProcessingStatus.BUILDING,
+        )
+
+        response = api_client.get(
+            player_album_url(album.id),
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['id'] == album.id
+        assert response.data['name'] == album.name
+        assert response.data['artist_name'] == (
+            album.owner.artist_profile.name
+        )
+        assert response.data['cover_image'] == (
+            album.cover_image.url if album.cover_image else None
+        )
+
+        tracks = response.data['tracks']
+
+        assert [track['id'] for track in tracks] == [
+            first_track.id,
+            second_track.id,
+        ]
+
+        assert tracks[0]['name'] == first_track.name
+        assert tracks[0]['duration'] == first_track.duration
+        assert tracks[0]['price'] == str(first_variant.product.price)
+        assert tracks[0]['is_favorite'] is False
+        assert tracks[0]['playback'] == {
+            'status': TrackGeneratedAudio.ProcessingStatus.READY,
+            'kind': 'preview',
+            'duration': 29,
+            'url': player_track_play_url(first_track.id),
+        }
+
+        assert tracks[1]['name'] == second_track.name
+        assert tracks[1]['playback'] == {
+            'status': TrackGeneratedAudio.ProcessingStatus.BUILDING,
+            'kind': None,
+            'duration': None,
+            'url': None,
+        }
+
+    def test_does_not_return_inactive_tracks(
+        self,
+        api_client,
+        player_album_url,
+        variant_factory,
+    ):
+        """Неактивные треки не попадают в очередь альбома."""
+        active_variant = variant_factory(
+            'track',
+            name='Активный трек',
+        )
+        active_track = active_variant.product.track
+        album = active_track.album
+
+        inactive_variant = variant_factory(
+            'track',
+            album=album,
+            name='Неактивный трек',
+        )
+        inactive_track = inactive_variant.product.track
+
+        active_track.position = 1
+        active_track.save(update_fields=('position',))
+
+        inactive_track.position = 2
+        inactive_track.is_active = False
+        inactive_track.save(
+            update_fields=(
+                'position',
+                'is_active',
+            ),
+        )
+
+        response = api_client.get(
+            player_album_url(album.id),
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert [track['id'] for track in response.data['tracks']] == [
+            active_track.id,
+        ]
+
+    def test_returns_favorite_state_for_authenticated_user(
+        self,
+        api_client,
+        listener_user,
+        player_album_url,
+        variant_factory,
+    ):
+        """Возвращает статус избранного для текущего пользователя."""
+        variant = variant_factory(
+            'track',
+            name='Избранный трек',
+        )
+        track = variant.product.track
+
+        Favorite.objects.create(
+            user=listener_user,
+            product_variant=variant,
+        )
+
+        api_client.force_authenticate(user=listener_user)
+
+        response = api_client.get(
+            player_album_url(track.album.id),
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['tracks'][0]['id'] == track.id
+        assert response.data['tracks'][0]['is_favorite'] is True
+
+    def test_returns_404_for_unpublished_album(
+        self,
+        api_client,
+        player_album_url,
+        variant_factory,
+    ):
+        """Неопубликованный альбом недоступен анонимному пользователю."""
+        variant = variant_factory('track')
+        album = variant.product.track.album
+
+        album.is_published = False
+        album.save(update_fields=('is_published',))
+
+        response = api_client.get(
+            player_album_url(album.id),
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+class TestPlayerTrackPlayAPI:
+    """Тесты запуска воспроизведения трека."""
+
+    @staticmethod
+    def create_track(variant_factory) -> Track:
+        """Создаёт публичный трек с товаром."""
+        variant = variant_factory('track')
+        return variant.product.track
+
+    @staticmethod
+    def create_ready_preview(track) -> TrackGeneratedAudio:
+        """Создаёт готовое preview трека."""
+        generated = TrackGeneratedAudio.objects.create(
+            track=track,
+            preview_status=TrackGeneratedAudio.ProcessingStatus.READY,
+            preview_duration=29,
+        )
+        generated.preview_file.save(
+            'preview.mp3',
+            ContentFile(b'preview-audio'),
+            save=True,
+        )
+        return generated
+
+    def test_ready_preview_redirects_to_audio_file(
+        self,
+        api_client,
+        player_track_play_url,
+        variant_factory,
+    ):
+        """Готовое preview перенаправляет на аудиофайл."""
+        track = self.create_track(variant_factory)
+        generated = self.create_ready_preview(track)
+
+        response = api_client.get(
+            player_track_play_url(track.id),
+        )
+
+        assert response.status_code == status.HTTP_302_FOUND
+        assert response['Location'] == generated.preview_file.url
+
+    def test_missing_generated_audio_returns_pending_status(
+        self,
+        api_client,
+        player_track_play_url,
+        variant_factory,
+    ):
+        """Трек без производного аудио считается ожидающим обработки."""
+        track = self.create_track(variant_factory)
+
+        response = api_client.get(
+            player_track_play_url(track.id),
+        )
+
+        assert response.status_code == status.HTTP_409_CONFLICT
+        assert response.data == {
+            'detail': 'Превью трека ещё готовится.',
+            'status': TrackGeneratedAudio.ProcessingStatus.PENDING,
+        }
+
+    @pytest.mark.parametrize(
+        'preview_status',
+        (
+            TrackGeneratedAudio.ProcessingStatus.PENDING,
+            TrackGeneratedAudio.ProcessingStatus.BUILDING,
+        ),
+        ids=(
+            'pending',
+            'building',
+        ),
+    )
+    def test_not_ready_preview_returns_409(
+        self,
+        api_client,
+        player_track_play_url,
+        variant_factory,
+        preview_status,
+    ):
+        """Неготовое preview возвращает 409 с текущим статусом."""
+        track = self.create_track(variant_factory)
+
+        TrackGeneratedAudio.objects.create(
+            track=track,
+            preview_status=preview_status,
+        )
+
+        response = api_client.get(
+            player_track_play_url(track.id),
+        )
+
+        assert response.status_code == status.HTTP_409_CONFLICT
+        assert response.data == {
+            'detail': 'Превью трека ещё готовится.',
+            'status': preview_status,
+        }
+
+    def test_failed_preview_returns_409(
+        self,
+        api_client,
+        player_track_play_url,
+        variant_factory,
+    ):
+        """Ошибка подготовки preview возвращает 409."""
+        track = self.create_track(variant_factory)
+
+        TrackGeneratedAudio.objects.create(
+            track=track,
+            preview_status=TrackGeneratedAudio.ProcessingStatus.FAILED,
+        )
+
+        response = api_client.get(
+            player_track_play_url(track.id),
+        )
+
+        assert response.status_code == status.HTTP_409_CONFLICT
+        assert response.data == {
+            'detail': 'Не удалось подготовить превью трека.',
+            'status': TrackGeneratedAudio.ProcessingStatus.FAILED,
+        }
+
+    def test_ready_preview_without_file_returns_404(
+        self,
+        api_client,
+        player_track_play_url,
+        variant_factory,
+    ):
+        """Статус ready без готового файла не выдаёт redirect."""
+        track = self.create_track(variant_factory)
+
+        TrackGeneratedAudio.objects.create(
+            track=track,
+            preview_status=TrackGeneratedAudio.ProcessingStatus.READY,
+            preview_duration=29,
+        )
+
+        response = api_client.get(
+            player_track_play_url(track.id),
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.data == {
+            'detail': 'Превью трека временно недоступно.',
+        }
+
+    def test_ready_preview_without_duration_returns_404(
+        self,
+        api_client,
+        player_track_play_url,
+        variant_factory,
+    ):
+        """Preview без длительности не выдаётся как готовое."""
+        track = self.create_track(variant_factory)
+
+        generated = TrackGeneratedAudio.objects.create(
+            track=track,
+            preview_status=TrackGeneratedAudio.ProcessingStatus.READY,
+        )
+        generated.preview_file.save(
+            'preview.mp3',
+            ContentFile(b'preview-audio'),
+            save=True,
+        )
+
+        response = api_client.get(
+            player_track_play_url(track.id),
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.data == {
+            'detail': 'Превью трека временно недоступно.',
+        }
+
+    def test_returns_404_for_inaccessible_track(
+        self,
+        api_client,
+        player_track_play_url,
+        variant_factory,
+    ):
+        """Трек неопубликованного альбома нельзя запустить."""
+        track = self.create_track(variant_factory)
+
+        track.album.is_published = False
+        track.album.save(update_fields=('is_published',))
+
+        response = api_client.get(
+            player_track_play_url(track.id),
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/store/tests/test_purchased_music_links.py
+++ b/store/tests/test_purchased_music_links.py
@@ -6,7 +6,12 @@ import pytest
 from django.utils import timezone
 from rest_framework import status
 
-from store.models import AlbumArchive, Order, OrderItem, Track
+from store.models import (
+    AlbumArchive,
+    Order,
+    OrderItem,
+    Track,
+)
 from store.services import DownloadLink
 
 pytestmark = pytest.mark.django_db
@@ -308,8 +313,8 @@ class TestPurchasedMusicArchiveDownloadLinkAPI:
         }
 
     @pytest.mark.parametrize(
-        ('archive_status', 'detail'),
-        [
+        ('archive_status', 'expected_detail'),
+        (
             (
                 AlbumArchive.Status.PENDING,
                 'Архив ещё готовится.',
@@ -322,13 +327,18 @@ class TestPurchasedMusicArchiveDownloadLinkAPI:
                 AlbumArchive.Status.FAILED,
                 'Не удалось подготовить архив.',
             ),
-        ],
+        ),
+        ids=(
+            'pending',
+            'building',
+            'failed',
+        ),
     )
     def test_not_ready_archive_returns_409(
         self,
         listener_user,
         archive_status,
-        detail,
+        expected_detail,
     ):
         """Неготовый архив возвращает 409 с текущим статусом."""
         album = self.create_full_access_album(listener_user)
@@ -347,7 +357,7 @@ class TestPurchasedMusicArchiveDownloadLinkAPI:
 
         assert response.status_code == status.HTTP_409_CONFLICT
         assert response.data == {
-            'detail': detail,
+            'detail': expected_detail,
             'status': archive_status,
         }
 

--- a/store/urls.py
+++ b/store/urls.py
@@ -18,6 +18,8 @@ from .views import (
     MerchKindViewSet,
     MerchViewSet,
     OrderViewSet,
+    PlayerAlbumView,
+    PlayerTrackPlayView,
     ProductCatalogListView,
     PromocodeViewSet,
     PurchasedMusicArchiveDownloadLinkView,
@@ -75,4 +77,14 @@ urlpatterns = [
         name='purchased-music-archive-download-link',
     ),
     path('cdek/widget', CDEKWidgetView.as_view(), name='cdek-widget'),
+    path(
+        'player/albums/<int:album_id>/',
+        PlayerAlbumView.as_view(),
+        name='player-album',
+    ),
+    path(
+        'player/tracks/<int:track_id>/play/',
+        PlayerTrackPlayView.as_view(),
+        name='player-play-track',
+    ),
 ]

--- a/store/views/__init__.py
+++ b/store/views/__init__.py
@@ -12,6 +12,10 @@ from .genre import GenreViewSet
 from .merch import MerchViewSet
 from .merch_kind import MerchKindViewSet
 from .order import OrderViewSet
+from .player import (
+    PlayerAlbumView,
+    PlayerTrackPlayView,
+)
 from .promocode import PromocodeViewSet
 from .purchased_music import (
     PurchasedMusicArchiveDownloadLinkView,
@@ -35,6 +39,8 @@ __all__ = [
     'MerchKindViewSet',
     'MerchViewSet',
     'OrderViewSet',
+    'PlayerAlbumView',
+    'PlayerTrackPlayView',
     'ProductCatalogListView',
     'PromocodeViewSet',
     'PurchasedMusicArchiveDownloadLinkView',

--- a/store/views/mixins/__init__.py
+++ b/store/views/mixins/__init__.py
@@ -8,9 +8,11 @@
 from .commerce import ProductActionMixin
 from .music_access import PurchasedMusicAccessMixin
 from .soft_delete import SoftDeleteMixin
+from .track import TrackReadQuerysetMixin
 
 __all__ = [
     'PurchasedMusicAccessMixin',
     'ProductActionMixin',
     'SoftDeleteMixin',
+    'TrackReadQuerysetMixin',
 ]

--- a/store/views/mixins/track.py
+++ b/store/views/mixins/track.py
@@ -1,0 +1,36 @@
+from django.db.models import BooleanField, Exists, OuterRef, Value
+
+from store.models import Favorite, Track
+
+
+class TrackReadQuerysetMixin:
+    """Подготавливает queryset треков для публичного чтения."""
+
+    def get_track_read_queryset(self, *, action: str):
+        """Возвращает треки с данными для публичного read-контракта."""
+        user = self.request.user
+
+        queryset = Track.objects.visible_for(
+            user=user,
+            action=action,
+        ).select_related(
+            'album',
+            'owner__artist_profile',
+            'product',
+        )
+
+        if user.is_authenticated:
+            favorite_subquery = Favorite.objects.filter(
+                user=user,
+                product_variant__product=OuterRef('product'),
+            )
+            return queryset.annotate(
+                is_favorite=Exists(favorite_subquery),
+            )
+
+        return queryset.annotate(
+            is_favorite=Value(
+                False,
+                output_field=BooleanField(),
+            ),
+        )

--- a/store/views/mixins/track.py
+++ b/store/views/mixins/track.py
@@ -4,13 +4,21 @@ from store.models import Favorite, Track
 
 
 class TrackReadQuerysetMixin:
-    """Подготавливает queryset треков для публичного чтения."""
+    """Подготавливает queryset треков для read-контрактов API."""
 
-    def get_track_read_queryset(self, *, action: str):
-        """Возвращает треки с данными для публичного read-контракта."""
+    def get_track_read_queryset(
+        self,
+        *,
+        action: str,
+        queryset=None,
+    ):
+        """Возвращает доступные треки с данными read-контракта."""
         user = self.request.user
 
-        queryset = Track.objects.visible_for(
+        if queryset is None:
+            queryset = Track.objects.all()
+
+        queryset = queryset.visible_for(
             user=user,
             action=action,
         ).select_related(

--- a/store/views/player.py
+++ b/store/views/player.py
@@ -10,10 +10,15 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from store.models import Album, Track, TrackGeneratedAudio
+from store.schema import (
+    player_album_schema,
+    player_track_play_schema,
+)
 from store.serializers import PlayerAlbumSerializer
 from store.views.mixins import TrackReadQuerysetMixin
 
 
+@player_album_schema
 class PlayerAlbumView(TrackReadQuerysetMixin, GenericAPIView):
     """Возвращает данные альбома для очереди плеера."""
 
@@ -58,6 +63,7 @@ class PlayerAlbumView(TrackReadQuerysetMixin, GenericAPIView):
         )
 
 
+@player_track_play_schema
 class PlayerTrackPlayView(APIView):
     """Перенаправляет на доступный источник воспроизведения трека."""
 
@@ -69,9 +75,6 @@ class PlayerTrackPlayView(APIView):
             Track.objects
             .visible_for(request.user, action='retrieve')
             .select_related(
-                'album',
-                'owner__artist_profile',
-                'product',
                 'generated',
             )
             .filter(pk=track_id)
@@ -116,7 +119,7 @@ class PlayerTrackPlayView(APIView):
                 status=status.HTTP_409_CONFLICT,
             )
 
-        if not generated.preview_file:
+        if not generated.preview_file or not generated.preview_duration:
             return Response(
                 {
                     'detail': 'Превью трека временно недоступно.',

--- a/store/views/player.py
+++ b/store/views/player.py
@@ -1,0 +1,127 @@
+"""API плеера для публичного preview и будущего stream."""
+
+from django.db.models import Prefetch
+from django.http import Http404
+from django.shortcuts import redirect
+from rest_framework import status
+from rest_framework.generics import GenericAPIView
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from store.models import Album, Track, TrackGeneratedAudio
+from store.serializers import PlayerAlbumSerializer
+from store.views.mixins import TrackReadQuerysetMixin
+
+
+class PlayerAlbumView(TrackReadQuerysetMixin, GenericAPIView):
+    """Возвращает данные альбома для очереди плеера."""
+
+    serializer_class = PlayerAlbumSerializer
+    permission_classes = (AllowAny,)
+    lookup_url_kwarg = 'album_id'
+
+    def get_queryset(self):
+        """Возвращает альбомы с доступными треками для плеера."""
+        tracks_queryset = (
+            self
+            .get_track_read_queryset(
+                action='retrieve',
+            )
+            .select_related('generated')
+            .order_by('position', 'id')
+        )
+
+        return (
+            Album.objects
+            .visible_for(
+                self.request.user,
+                action='retrieve',
+            )
+            .select_related(
+                'owner__artist_profile',
+            )
+            .prefetch_related(
+                Prefetch(
+                    'tracks',
+                    queryset=tracks_queryset,
+                ),
+            )
+        )
+
+    def get(self, request, *args, **kwargs):
+        """Возвращает альбом и очередь его треков."""
+        album = self.get_object()
+
+        return Response(
+            self.get_serializer(album).data,
+        )
+
+
+class PlayerTrackPlayView(APIView):
+    """Перенаправляет на доступный источник воспроизведения трека."""
+
+    permission_classes = (AllowAny,)
+
+    def get(self, request, track_id: int):
+        """Перенаправляет на preview, если оно готово."""
+        track = (
+            Track.objects
+            .visible_for(request.user, action='retrieve')
+            .select_related(
+                'album',
+                'owner__artist_profile',
+                'product',
+                'generated',
+            )
+            .filter(pk=track_id)
+            .first()
+        )
+
+        if track is None:
+            raise Http404
+
+        generated = getattr(track, 'generated', None)
+
+        if generated is None:
+            return Response(
+                {
+                    'detail': 'Превью трека ещё готовится.',
+                    'status': TrackGeneratedAudio.ProcessingStatus.PENDING,
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        if generated.preview_status in (
+            TrackGeneratedAudio.ProcessingStatus.PENDING,
+            TrackGeneratedAudio.ProcessingStatus.BUILDING,
+        ):
+            return Response(
+                {
+                    'detail': 'Превью трека ещё готовится.',
+                    'status': generated.preview_status,
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        if (
+            generated.preview_status
+            == TrackGeneratedAudio.ProcessingStatus.FAILED
+        ):
+            return Response(
+                {
+                    'detail': 'Не удалось подготовить превью трека.',
+                    'status': generated.preview_status,
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        if not generated.preview_file:
+            return Response(
+                {
+                    'detail': 'Превью трека временно недоступно.',
+                },
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        return redirect(generated.preview_file.url)

--- a/store/views/player.py
+++ b/store/views/player.py
@@ -27,7 +27,7 @@ class PlayerAlbumView(TrackReadQuerysetMixin, GenericAPIView):
     lookup_url_kwarg = 'album_id'
 
     def get_queryset(self):
-        """Возвращает альбомы с доступными треками для плеера."""
+        """Возвращает альбом с доступными треками для плеера."""
         tracks_queryset = (
             self
             .get_track_read_queryset(

--- a/store/views/player.py
+++ b/store/views/player.py
@@ -1,5 +1,7 @@
 """API плеера для публичного preview и будущего stream."""
 
+import logging
+
 from django.db.models import Prefetch
 from django.http import Http404
 from django.shortcuts import redirect
@@ -16,6 +18,8 @@ from store.schema import (
 )
 from store.serializers import PlayerAlbumSerializer
 from store.views.mixins import TrackReadQuerysetMixin
+
+logger = logging.getLogger(__name__)
 
 
 @player_album_schema
@@ -120,11 +124,47 @@ class PlayerTrackPlayView(APIView):
             )
 
         if not generated.preview_file or not generated.preview_duration:
-            return Response(
-                {
-                    'detail': 'Превью трека временно недоступно.',
-                },
-                status=status.HTTP_404_NOT_FOUND,
+            return self._preview_unavailable_response(
+                code='preview_file_missing',
             )
 
-        return redirect(generated.preview_file.url)
+        preview_file = generated.preview_file
+
+        try:
+            if not preview_file.storage.exists(preview_file.name):
+                logger.warning(
+                    'Preview file is missing in storage: '
+                    'track_id=%s generated_audio_id=%s file_name=%s',
+                    track.pk,
+                    generated.pk,
+                    preview_file.name,
+                )
+                return self._preview_unavailable_response(
+                    code='preview_file_not_found',
+                )
+
+            preview_url = preview_file.url
+        except Exception:
+            logger.exception(
+                'Could not access preview file in storage: '
+                'track_id=%s generated_audio_id=%s file_name=%s',
+                track.pk,
+                generated.pk,
+                preview_file.name,
+            )
+            return self._preview_unavailable_response(
+                code='preview_storage_unavailable',
+            )
+
+        return redirect(preview_url)
+
+    @staticmethod
+    def _preview_unavailable_response(code: str) -> Response:
+        """Возвращает ошибку недоступного preview."""
+        return Response(
+            {
+                'detail': 'Превью трека временно недоступно.',
+                'code': code,
+            },
+            status=status.HTTP_404_NOT_FOUND,
+        )

--- a/store/views/track.py
+++ b/store/views/track.py
@@ -58,6 +58,7 @@ class TrackViewSet(
         """Возвращает треки, доступные текущему пользователю."""
         return self.get_track_read_queryset(
             action=self.action,
+            queryset=super().get_queryset(),
         )
 
     def create(self, request, *args, **kwargs):

--- a/store/views/track.py
+++ b/store/views/track.py
@@ -1,15 +1,18 @@
 """ViewSet для работы с моделью track."""
 
-from django.db.models import BooleanField, Exists, OuterRef, Value
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import filters, status, viewsets
 from rest_framework.response import Response
 
 from common.permissions import IsArtist, IsStoreObjectOwnerOrReadOnly
 
-from .mixins import ProductActionMixin, SoftDeleteMixin
+from .mixins import (
+    ProductActionMixin,
+    SoftDeleteMixin,
+    TrackReadQuerysetMixin,
+)
 from store.filters import TrackFilter
-from store.models import Favorite, Track
+from store.models import Track
 from store.schema import track_schema
 from store.serializers import (
     TrackReadDetailSerializer,
@@ -19,7 +22,12 @@ from store.serializers import (
 
 
 @track_schema
-class TrackViewSet(ProductActionMixin, SoftDeleteMixin, viewsets.ModelViewSet):
+class TrackViewSet(
+    TrackReadQuerysetMixin,
+    ProductActionMixin,
+    SoftDeleteMixin,
+    viewsets.ModelViewSet,
+):
     """API для работы с треками."""
 
     queryset = Track.objects.all()
@@ -47,32 +55,10 @@ class TrackViewSet(ProductActionMixin, SoftDeleteMixin, viewsets.ModelViewSet):
         return TrackReadSerializer
 
     def get_queryset(self):
-        user = self.request.user
-
-        queryset = (
-            super()
-            .get_queryset()
-            .visible_for(user=user, action=self.action)
-            .select_related(
-                'album',
-                'owner__artist_profile',
-                'product',
-            )
+        """Возвращает треки, доступные текущему пользователю."""
+        return self.get_track_read_queryset(
+            action=self.action,
         )
-
-        if user.is_authenticated:
-            favorite_subquery = Favorite.objects.filter(
-                user=user,
-                product_variant__product=OuterRef('product'),
-            )
-            queryset = queryset.annotate(
-                is_favorite=Exists(favorite_subquery),
-            )
-        else:
-            queryset = queryset.annotate(
-                is_favorite=Value(False, output_field=BooleanField()),
-            )
-        return queryset
 
     def create(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)


### PR DESCRIPTION
API для будущего плеера.

Добавлены два endpoint:

- GET /player/albums/<album_id>/ — возвращает очередь треков релиза с данными для воспроизведения preview.
- GET /player/tracks/<track_id>/play/ — проверяет доступность источника и перенаправляет браузер на аудиофайл.

Добавлены тесты.

TODO:
- Интегрировать player API с купленной музыкой: для доступных пользователю треков отдавать full stream и добавить ссылки на скачивание оригиналов.