### PR TITLE
chore/docker-optimization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,12 @@ nginx
 .git
 .github
 README.md
+.venv
+.venv/
+__pycache__
+**/__pycache__
+*.py[cod]
+.pytest_cache
+.ruff_cache
+.mypy_cache
+tmp

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: ./
+          file: ./Dockerfile.prod
           push: true
           tags: ${{ secrets.DOCKER_USERNAME }}/zvuchno_backend:latest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ RUN apt-get update \
 COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir
 COPY . .
-CMD ["gunicorn", "--bind", "0.0.0.0:8000", "--forwarded-allow-ips=*", "--timeout", "300", "config.wsgi"]
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -3,7 +3,7 @@ WORKDIR /app
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ffmpeg \
     && rm -rf /var/lib/apt/lists/*
-COPY requirements.txt .
-RUN pip install -r requirements.txt --no-cache-dir
+COPY requirements.prod.txt .
+RUN pip install -r requirements.prod.txt --no-cache-dir
 COPY . .
 CMD ["gunicorn", "--bind", "0.0.0.0:8000", "--forwarded-allow-ips=*", "--timeout", "300", "config.wsgi"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help up up-d start start-d build down restart logs rebuild clean \
+.PHONY: help up up-d start start-d stop build down restart logs rebuild clean \
 	shell migrations migrate test collectstatic
 
 help:
@@ -7,6 +7,7 @@ help:
 	@echo "  make up-d          Собрать Docker image и запустить в фоне"
 	@echo "  make start         Запустить без пересборки"
 	@echo "  make start-d       Запустить без пересборки в фоне"
+	@echo "  make stop          Остановить контейнеры без удаления"
 	@echo "  make build         Собрать Docker images"
 	@echo "  make rebuild       Пересобрать images без кэша и запустить в фоне"
 	@echo "  make down          Остановить и удалить контейнеры"
@@ -26,10 +27,13 @@ up: build
 	docker compose up
 
 start:
-	docker compose up
+	docker compose start
 
 start-d:
-	docker compose up -d
+	docker compose start -d
+
+stop:
+	docker compose stop
 
 build:
 	docker compose build

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,23 @@
-.PHONY: \
-	up up-d start start-d build \
-	down restart logs rebuild clean \
-	shell migrations migrate test
+.PHONY: help up up-d start start-d build down restart logs rebuild clean \
+	shell migrations migrate test collectstatic
+
+help:
+	@echo "Доступные команды:"
+	@echo "  make up            Собрать Docker image и запустить проект"
+	@echo "  make up-d          Собрать Docker image и запустить в фоне"
+	@echo "  make start         Запустить без пересборки"
+	@echo "  make start-d       Запустить без пересборки в фоне"
+	@echo "  make build         Собрать Docker images"
+	@echo "  make rebuild       Пересобрать images без кэша и запустить в фоне"
+	@echo "  make down          Остановить и удалить контейнеры"
+	@echo "  make restart       Перезапустить контейнеры"
+	@echo "  make logs          Показать логи"
+	@echo "  make clean         Удалить контейнеры и неиспользуемый build-кэш"
+	@echo "  make shell         Открыть Django shell"
+	@echo "  make migrations    Создать миграции"
+	@echo "  make migrate       Применить миграции"
+	@echo "  make collectstatic Собрать статические файлы"
+	@echo "  make test          Запустить тесты"
 
 up-d: build
 	docker compose up -d
@@ -16,7 +32,7 @@ start-d:
 	docker compose up -d
 
 build:
-	docker compose build backend
+	docker compose build
 
 down:
 	docker compose down
@@ -28,7 +44,7 @@ logs:
 	docker compose logs -f
 
 rebuild:
-	docker compose build --no-cache backend
+	docker compose build --no-cache
 	docker compose up -d
 
 clean:
@@ -46,3 +62,6 @@ migrate:
 
 test:
 	docker compose exec backend pytest
+
+collectstatic:
+	docker compose exec backend python manage.py collectstatic --noinput

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+.PHONY: \
+	up up-d start start-d build \
+	down restart logs rebuild clean \
+	shell migrations migrate test
+
+up-d: build
+	docker compose up -d
+
+up: build
+	docker compose up
+
+start:
+	docker compose up
+
+start-d:
+	docker compose up -d
+
+build:
+	docker compose build backend
+
+down:
+	docker compose down
+
+restart:
+	docker compose restart
+
+logs:
+	docker compose logs -f
+
+rebuild:
+	docker compose build --no-cache backend
+	docker compose up -d
+
+clean:
+	docker compose down --remove-orphans
+	docker builder prune -f
+
+shell:
+	docker compose exec backend python manage.py shell
+
+migrations:
+	docker compose exec backend python manage.py makemigrations
+
+migrate:
+	docker compose exec backend python manage.py migrate
+
+test:
+	docker compose exec backend pytest

--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ Backend API проекта **Звучно**.
 * Swagger UI / Redoc
 * django-allauth
 * SimpleJWT
-* SQLite (для локальной разработки)
-* PostgreSQL
+* SQLite (для локального запуска без Docker)
+* PostgreSQL 17 (Docker / production)
+* Redis 7
+* Celery
 * Docker / Docker Compose
 * Nginx
 * Gunicorn
@@ -25,16 +27,10 @@ Backend API проекта **Звучно**.
 
 
 
-Основные зависимости:
+Полный список зависимостей находится в:
 
-```
-Django==5.2.12
-djangorestframework==3.16.1
-django-allauth==65.14.3
-djangorestframework_simplejwt==5.5.1
-django-filter==25.2
-ruff==0.15.5
-```
+* `requirements.txt` — локальная разработка и тестирование;
+* `requirements.prod.txt` — production runtime.
 
 ---
 
@@ -86,9 +82,12 @@ pre-commit run --all-files
 
 ---
 
-## 4. .env файл
-Пример - env.example
+## 4. Настроить окружение
+Создайте `.env` в корне проекта на основе `.env.example`.
+Проект поддерживает два локальных сценария:
 
+- запуск без Docker — Django запускается напрямую из виртуального окружения, по умолчанию можно использовать SQLite;
+- запуск через Docker Compose — используется полное окружение с PostgreSQL, Redis, Celery и Nginx.
 ---
 
 ## 5. Применить миграции
@@ -124,28 +123,142 @@ http://127.0.0.1:8000
 ```
 http://127.0.0.1:8000/admin
 ```
-### Запуск через Docker
+## Запуск через Docker
 
-Этот метод запускает полную связку: Django + PostgreSQL + Gunicorn + Nginx.
+Docker Compose запускает полное локальное окружение:
 
-**Подготовьте окружение:**
+* Django;
+* PostgreSQL;
+* Redis;
+* Celery workers;
+* Celery Beat;
+* Flower;
+* Nginx;
+* bot.
 
-Создайте файл .env в корневой папке проекта на основе примера: env.example
+Локальный backend запускается через Django `runserver`.
 
-Соберите и запустите контейнеры:
+Для production используется отдельный `Dockerfile.prod`, в котором backend запускается через Gunicorn.
+
+### Подготовка окружения
+
+Создайте `.env` в корневой папке проекта на основе `.env.example`.
+
+### Через Makefile
+
+Для основных Docker-команд в проекте используется `Makefile`.
+
+Посмотреть доступные команды:
+
+```bash
+make help
 ```
-docker compose up --build
+
+Собрать Docker image и запустить проект:
+
+```bash
+make up
 ```
-Подготовьте базу данных и статику при первом запуске:
+
+Запустить проект в фоне:
+
+```bash
+make up-d
 ```
+
+Если backend image уже собран и пересборка не требуется:
+
+```bash
+make start
+```
+
+или в фоне:
+
+```bash
+make start-d
+```
+
+После изменения `Dockerfile` или `requirements.txt`:
+
+```bash
+make build
+```
+
+Полностью пересобрать backend без Docker build cache и запустить в фоне:
+
+```bash
+make rebuild
+```
+
+Остановить контейнеры:
+
+```bash
+make down
+```
+
+Посмотреть логи:
+
+```bash
+make logs
+```
+
+### Напрямую через Docker Compose
+
+`Makefile` является удобной обёрткой над Docker Compose. Команды можно выполнять и напрямую.
+
+Собрать image:
+
+```bash
+docker compose build
+```
+
+Запустить проект:
+
+```bash
+docker compose up
+```
+
+или в фоне:
+
+```bash
+docker compose up -d
+```
+
+Подготовить базу данных и статику при первом запуске:
+
+```bash
 # Миграции
 docker compose exec backend python manage.py migrate
+
 # Сбор статических файлов
 docker compose exec backend python manage.py collectstatic
 ```
+
 Проект доступен по адресу: [http://localhost:8000](http://localhost:8000)
 
+### Полезные команды Makefile
 
+| Команда | Назначение                                      |
+|---|-------------------------------------------------|
+| `make help` | Показать доступные команды                      |
+| `make up` | Собрать Docker image и запустить проект         |
+| `make up-d` | Собрать Docker image и запустить проект в фоне  |
+| `make start` | Запустить проект без пересборки                 |
+| `make start-d` | Запустить проект без пересборки в фоне          |
+| `make build` | Собрать Docker image                            |
+| `make rebuild` | Пересобрать images без cache и запустить в фоне |
+| `make down` | Остановить и удалить контейнеры                 |
+| `make restart` | Перезапустить контейнеры                        |
+| `make logs` | Следить за логами контейнеров                   |
+| `make clean` | Удалить контейнеры и неиспользуемый build cache |
+| `make shell` | Открыть Django shell                            |
+| `make migrations` | Создать миграции                                |
+| `make migrate` | Применить миграции                              |
+| `make test` | Запустить тесты                                 |
+| `make collectstatic` | Собрать статические файлы |
+
+> [!NOTE]
+> `make clean` не удаляет Docker volumes, поэтому локальная PostgreSQL база сохраняется.
 
 ### Мониторинг Celery через Flower
 
@@ -200,27 +313,19 @@ users.CoreUser
 AUTH_USER_MODEL = "users.CoreUser"
 ```
 
-При работе с пользователем используйте:
-
-```python
-from django.contrib.auth import get_user_model
-
-User = get_user_model()
-```
-
 ---
 
 # База данных
 
-Для локальной разработки используется **SQLite**.
-
+При локальном запуске без Docker может использоваться **SQLite**.
 Файл базы (`db.sqlite3`) не хранится в репозитории.
 
-После клонирования проекта выполните:
+При запуске через Docker Compose используется **PostgreSQL 17**.
 
-```
-python manage.py migrate
-```
+Данные PostgreSQL хранятся в Docker volume `pg_data` и сохраняются между обычными остановками и пересозданием контейнеров.
+
+> [!WARNING]
+> Команда `docker compose down -v` удаляет volumes, включая локальную PostgreSQL базу.
 
 ---
 
@@ -228,25 +333,43 @@ python manage.py migrate
 
 Создать миграции:
 
-```
+```bash
 python manage.py makemigrations
+```
+
+или в Docker:
+
+```bash
+make migrations
 ```
 
 Применить миграции:
 
-```
+```bash
 python manage.py migrate
+```
+
+или в Docker:
+
+```bash
+make migrate
 ```
 
 Запустить shell:
 
-```
+```bash
 python manage.py shell
 ```
 
-Запустить проверку:
+или в Docker:
 
+```bash
+make shell
 ```
+
+Запустить проверку Django:
+
+```bash
 python manage.py check
 ```
 
@@ -283,6 +406,11 @@ pytest
 или многопоточно (указать auto или подобрать количество потоков вручную):
 ```
 pytest -n auto
+```
+Запуск внутри Docker:
+
+```bash
+make test
 ```
 
 # Профилирование и оптимизация (Silk)

--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ docker compose exec backend python manage.py collectstatic
 | `make up-d` | Собрать Docker image и запустить проект в фоне  |
 | `make start` | Запустить проект без пересборки                 |
 | `make start-d` | Запустить проект без пересборки в фоне          |
+| `make stop` | Остановить контейнеры без удаления |
 | `make build` | Собрать Docker image                            |
 | `make rebuild` | Пересобрать images без cache и запустить в фоне |
 | `make down` | Остановить и удалить контейнеры                 |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,10 @@ services:
       timeout: 5s
       retries: 5
   backend:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: zvuchno_backend:dev
     env_file: .env
     command: python manage.py runserver 0.0.0.0:8000
     volumes:
@@ -47,12 +50,12 @@ services:
         max-size: "10m"
         max-file: "5"
     depends_on:
-        db:
-          condition: service_healthy
-        redis:
-          condition: service_healthy
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
   celery_worker:
-    build: .
+    image: zvuchno_backend:dev
     env_file: .env
     command: >
       celery -A config worker
@@ -68,7 +71,7 @@ services:
         condition: service_healthy
 
   celery_archives:
-    build: .
+    image: zvuchno_backend:dev
     env_file: .env
     command: >
       celery -A config worker
@@ -85,7 +88,7 @@ services:
       redis:
         condition: service_healthy
   celery_media:
-    build: .
+    image: zvuchno_backend:dev
     env_file: .env
     command: >
       celery -A config worker
@@ -102,7 +105,7 @@ services:
       redis:
         condition: service_healthy
   celery_beat:
-    build: .
+    image: zvuchno_backend:dev
     env_file: .env
     command: celery -A config beat -l warning --schedule=/var/run/celery/celerybeat-schedule
     volumes:
@@ -118,8 +121,7 @@ services:
       redis:
         condition: service_healthy
   flower:
-    build:
-      context: .
+    image: zvuchno_backend:dev
     env_file:
       - .env
     command: >
@@ -140,7 +142,7 @@ services:
     ports:
       - '127.0.0.1:5555:5555'
   bot:
-    build: .
+    image: zvuchno_backend:dev
     env_file: .env
     command: python manage.py runbot
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,3 @@
-x-backend-build: &backend-build
-  build:
-    context: .
-    dockerfile: Dockerfile
-
 volumes:
   pg_data:
   static:
@@ -39,7 +34,9 @@ services:
       timeout: 5s
       retries: 5
   backend:
-    <<: *backend-build
+    build:
+      context: .
+      dockerfile: Dockerfile
     image: zvuchno_backend:dev
     env_file: .env
     command: python manage.py runserver 0.0.0.0:8000
@@ -58,7 +55,7 @@ services:
       redis:
         condition: service_healthy
   celery_worker:
-    <<: *backend-build
+    image: zvuchno_backend:dev
     env_file: .env
     command: >
       celery -A config worker
@@ -72,9 +69,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-
   celery_archives:
-    <<: *backend-build
+    image: zvuchno_backend:dev
     env_file: .env
     command: >
       celery -A config worker
@@ -91,7 +87,7 @@ services:
       redis:
         condition: service_healthy
   celery_media:
-    <<: *backend-build
+    image: zvuchno_backend:dev
     env_file: .env
     command: >
       celery -A config worker
@@ -108,7 +104,7 @@ services:
       redis:
         condition: service_healthy
   celery_beat:
-    <<: *backend-build
+    image: zvuchno_backend:dev
     env_file: .env
     command: celery -A config beat -l warning --schedule=/var/run/celery/celerybeat-schedule
     volumes:
@@ -124,7 +120,7 @@ services:
       redis:
         condition: service_healthy
   flower:
-    <<: *backend-build
+    image: zvuchno_backend:dev
     env_file:
       - .env
     command: >
@@ -145,7 +141,7 @@ services:
     ports:
       - '127.0.0.1:5555:5555'
   bot:
-    <<: *backend-build
+    image: zvuchno_backend:dev
     env_file: .env
     command: python manage.py runbot
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,8 @@
+x-backend-build: &backend-build
+  build:
+    context: .
+    dockerfile: Dockerfile
+
 volumes:
   pg_data:
   static:
@@ -34,9 +39,7 @@ services:
       timeout: 5s
       retries: 5
   backend:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    <<: *backend-build
     image: zvuchno_backend:dev
     env_file: .env
     command: python manage.py runserver 0.0.0.0:8000
@@ -55,7 +58,7 @@ services:
       redis:
         condition: service_healthy
   celery_worker:
-    image: zvuchno_backend:dev
+    <<: *backend-build
     env_file: .env
     command: >
       celery -A config worker
@@ -71,7 +74,7 @@ services:
         condition: service_healthy
 
   celery_archives:
-    image: zvuchno_backend:dev
+    <<: *backend-build
     env_file: .env
     command: >
       celery -A config worker
@@ -88,7 +91,7 @@ services:
       redis:
         condition: service_healthy
   celery_media:
-    image: zvuchno_backend:dev
+    <<: *backend-build
     env_file: .env
     command: >
       celery -A config worker
@@ -105,7 +108,7 @@ services:
       redis:
         condition: service_healthy
   celery_beat:
-    image: zvuchno_backend:dev
+    <<: *backend-build
     env_file: .env
     command: celery -A config beat -l warning --schedule=/var/run/celery/celerybeat-schedule
     volumes:
@@ -121,7 +124,7 @@ services:
       redis:
         condition: service_healthy
   flower:
-    image: zvuchno_backend:dev
+    <<: *backend-build
     env_file:
       - .env
     command: >
@@ -142,7 +145,7 @@ services:
     ports:
       - '127.0.0.1:5555:5555'
   bot:
-    image: zvuchno_backend:dev
+    <<: *backend-build
     env_file: .env
     command: python manage.py runbot
     volumes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ nplusone==1.0.0
 oauthlib==3.3.1
 phonenumbers==9.0.25
 pillow==12.1.1
+psycopg2-binary==2.9.11
 pre-commit==4.5.1
 pycparser==3.0
 pytest==9.0.2


### PR DESCRIPTION
Разделены локальный и production Dockerfile: локально используются dev-зависимости и runserver, в CI/CD — Dockerfile.prod с Gunicorn.

Все backend-сервисы в Docker Compose переведены на общий локальный image zvuchno_backend:dev.

Добавлен Makefile для основных команд запуска, сборки, миграций, тестов и логов.

Обновлён .dockerignore, чтобы сократить build context.

В локальные зависимости добавлен psycopg2-binary.

README актуализирован под два сценария запуска: без Docker и через Docker/Makefile.