### PR TITLE
feat/539-admin-legal-profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ help:
 	@echo "  make down          Остановить и удалить контейнеры"
 	@echo "  make restart       Перезапустить контейнеры"
 	@echo "  make logs          Показать логи"
+	@echo "  make logs-backend          Показать логи backend"
 	@echo "  make clean         Удалить контейнеры и неиспользуемый build-кэш"
 	@echo "  make shell         Открыть Django shell"
 	@echo "  make migrations    Создать миграции"
@@ -46,6 +47,9 @@ restart:
 
 logs:
 	docker compose logs -f
+
+logs-backend:
+	docker compose logs -f backend
 
 rebuild:
 	docker compose build --no-cache

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+n ?= 1
+
 .PHONY: help up up-d start start-d stop build down restart logs rebuild clean \
 	shell migrations migrate test collectstatic
 
@@ -69,7 +71,7 @@ migrate:
 	docker compose exec backend python manage.py migrate
 
 test:
-	docker compose exec backend pytest
+	docker compose exec backend pytest -n $(n)
 
 collectstatic:
 	docker compose exec backend python manage.py collectstatic --noinput

--- a/store/admin/album.py
+++ b/store/admin/album.py
@@ -316,6 +316,11 @@ class AlbumAdmin(
 
         js = ('store/admin/album_track_upload.js',)
 
+    autocomplete_fields = (
+        'artist',
+        'genre',
+    )
+
     def get_readonly_fields(self, request, obj=None):
         """Возвращает поля, недоступные для ручного изменения."""
         readonly_fields = tuple(

--- a/store/admin/track.py
+++ b/store/admin/track.py
@@ -178,6 +178,8 @@ class TrackAdmin(
     )
     inlines = (ProductInline, TrackGeneratedAudioInline)
 
+    autocomplete_fields = ('album',)
+
     @admin.display(
         description='Артист',
         ordering='album__artist__name',

--- a/users/admin/artist_legal_profile.py
+++ b/users/admin/artist_legal_profile.py
@@ -11,6 +11,12 @@ from users.models import (
     ArtistLegalProfile,
 )
 
+VERIFICATION_MODELS = {
+    'identity_data': ArtistIdentityData,
+    'bank_data': ArtistBankData,
+    'company_data': ArtistCompanyData,
+}
+
 
 class ArtistIdentityDataInline(admin.StackedInline):
     """Инлайн паспортных данных артиста."""
@@ -91,12 +97,6 @@ class ArtistLegalProfileAdmin(admin.ModelAdmin):
         ArtistCompanyDataInline,
     )
 
-    readonly_fields = (
-        'artist_link',
-        'created_at',
-        'updated_at',
-    )
-
     list_display = (
         'id',
         'user',
@@ -148,6 +148,8 @@ class ArtistLegalProfileAdmin(admin.ModelAdmin):
             {
                 'fields': (
                     'recipient_type',
+                    'verification_readiness',
+                    'verification_missing_fields',
                     'is_verified',
                     'comment',
                 ),
@@ -184,6 +186,31 @@ class ArtistLegalProfileAdmin(admin.ModelAdmin):
         url = reverse('admin:users_artistprofile_change', args=[artist.pk])
         return format_html('<a href="{}">{}</a>', url, artist.name)
 
+    @admin.display(
+        description='Готов к проверке',
+        boolean=True,
+    )
+    def verification_readiness(self, obj):
+        if not obj:
+            return False
+        return obj.is_ready_for_verification
+
+    @admin.display(description='Не заполнено для проверки')
+    def verification_missing_fields(self, obj):
+        """Возвращает незаполненные обязательные данные."""
+        if not obj:
+            return '—'
+
+        missing_fields = obj.get_verification_missing_fields()
+
+        if not missing_fields:
+            return '—'
+
+        return ', '.join(
+            str(self._get_verification_field_label(field))
+            for field in missing_fields
+        )
+
     def get_queryset(self, request):
         """Оптимизирует запросы списка юридических профилей."""
         return (
@@ -214,9 +241,21 @@ class ArtistLegalProfileAdmin(admin.ModelAdmin):
             'artist_link',
             'created_at',
             'updated_at',
+            'verification_readiness',
+            'verification_missing_fields',
         ]
 
         if obj:
             readonly_fields.append('user')
 
         return readonly_fields
+
+    def _get_verification_field_label(self, field_name) -> str:
+        """Возвращает название обязательного поля для отображения."""
+        if '.' not in field_name:
+            return ArtistLegalProfile._meta.get_field(field_name).verbose_name
+
+        prefix, related_field = field_name.split('.', 1)
+        model = VERIFICATION_MODELS[prefix]
+
+        return model._meta.get_field(related_field).verbose_name

--- a/users/admin/artist_legal_profile.py
+++ b/users/admin/artist_legal_profile.py
@@ -1,6 +1,7 @@
 """Модуль админки юридических данных артиста."""
 
 from django.contrib import admin
+from django.db import models
 from django.urls import reverse
 from django.utils.html import format_html
 
@@ -87,6 +88,63 @@ class ArtistCompanyDataInline(admin.StackedInline):
     )
 
 
+class VerificationReadinessFilter(admin.SimpleListFilter):
+    """Фильтр по готовности юридического профиля к проверке."""
+
+    title = 'готов к проверке'
+    parameter_name = 'verification_readiness'
+
+    def lookups(self, request, model_admin):
+        return (
+            ('yes', 'Да'),
+            ('no', 'Нет'),
+        )
+
+    def queryset(self, request, queryset):
+        """Фильтрует профили по готовности к ручной проверке.
+
+        Важно: условие повторяет бизнес-правило
+        ArtistLegalProfile.is_ready_for_verification на уровне SQL.
+        При изменении обязательных полей проверки необходимо обновить
+        и этот фильтр.
+        """
+        ready_queryset = queryset.filter(
+            bank_data__bik__gt='',
+            bank_data__checking_account__gt='',
+        ).filter(
+            models.Q(
+                recipient_type__in=(
+                    ArtistLegalProfile.RecipientType.SELF_EMPLOYED,
+                    ArtistLegalProfile.RecipientType.INDIVIDUAL_ENTREPRENEUR,
+                ),
+                identity_data__last_name__gt='',
+                identity_data__first_name__gt='',
+                identity_data__birth_date__isnull=False,
+                identity_data__registration_address__gt='',
+                identity_data__passport_series__gt='',
+                identity_data__passport_number__gt='',
+                identity_data__passport_issued_by__gt='',
+                identity_data__passport_issue_date__isnull=False,
+                identity_data__inn__gt='',
+            )
+            | models.Q(
+                recipient_type=ArtistLegalProfile.RecipientType.LEGAL_ENTITY,
+                company_data__company_name__gt='',
+                company_data__company_address__gt='',
+                company_data__inn__gt='',
+                company_data__ogrn__gt='',
+            ),
+        )
+
+        if self.value() == 'yes':
+            return ready_queryset
+
+        if self.value() == 'no':
+            return queryset.exclude(pk__in=ready_queryset.values('pk'))
+
+        return queryset
+
+
 @admin.register(ArtistLegalProfile)
 class ArtistLegalProfileAdmin(admin.ModelAdmin):
     """Админка юридического профиля артиста."""
@@ -103,12 +161,14 @@ class ArtistLegalProfileAdmin(admin.ModelAdmin):
         'artist_name',
         'email',
         'recipient_type',
+        'verification_readiness',
         'is_verified',
         'updated_at',
     )
     list_display_links = ('id', 'user')
     list_filter = (
         'recipient_type',
+        VerificationReadinessFilter,
         'is_verified',
         'updated_at',
         'created_at',

--- a/users/admin/artist_legal_profile.py
+++ b/users/admin/artist_legal_profile.py
@@ -92,7 +92,6 @@ class ArtistLegalProfileAdmin(admin.ModelAdmin):
     )
 
     readonly_fields = (
-        'user',
         'artist_link',
         'created_at',
         'updated_at',
@@ -165,9 +164,7 @@ class ArtistLegalProfileAdmin(admin.ModelAdmin):
         ),
     )
 
-    def has_add_permission(self, request):
-        """Запрещает ручное создание юридических профилей через админку."""
-        return False
+    autocomplete_fields = ('user',)
 
     @admin.display(description='Артист')
     def artist_name(self, obj):
@@ -210,3 +207,16 @@ class ArtistLegalProfileAdmin(admin.ModelAdmin):
         actions = super().get_actions(request)
         actions.pop('delete_selected', None)
         return actions
+
+    def get_readonly_fields(self, request, obj=None):
+        """Возвращает поля только для чтения."""
+        readonly_fields = [
+            'artist_link',
+            'created_at',
+            'updated_at',
+        ]
+
+        if obj:
+            readonly_fields.append('user')
+
+        return readonly_fields

--- a/users/admin/user.py
+++ b/users/admin/user.py
@@ -103,6 +103,9 @@ class CoreUserAdmin(UserAdmin):
     search_fields = (
         'email',
         'username',
+        'phone',
+        'artist_profile__name',
+        'artist_profile__slug',
     )
     ordering = ('-date_joined',)
     fieldsets = (

--- a/users/models/artist/bank_data.py
+++ b/users/models/artist/bank_data.py
@@ -75,6 +75,8 @@ class ArtistBankData(TimestampModel):
             )
         if self.checking_account:
             self.checking_account = normalize_digits(self.checking_account)
+        if self.bank_name:
+            self.bank_name = self.bank_name.strip()
 
     class Meta:
         verbose_name = 'банковские данные'

--- a/users/models/artist/company_data.py
+++ b/users/models/artist/company_data.py
@@ -63,6 +63,12 @@ class ArtistCompanyData(TimestampModel):
         if self.ogrn:
             self.ogrn = normalize_digits(self.ogrn)
 
+        if self.company_name:
+            self.company_name = self.company_name.strip()
+
+        if self.company_address:
+            self.company_address = self.company_address.strip()
+
     def save(self, *args, **kwargs):
         """Сохраняет объект после полной валидации модели."""
         self.full_clean()

--- a/users/models/artist/legal_profile.py
+++ b/users/models/artist/legal_profile.py
@@ -1,7 +1,4 @@
-"""Модель юридического профиля артиста.
-
-TODO: валидация комбинаций всех данных.
-"""
+"""Модель юридического профиля артиста."""
 
 from django.conf import settings
 from django.db import models
@@ -14,6 +11,30 @@ from users.constants import (
     RECIPIENT_TYPE_MAX_LENGTH,
 )
 from users.querysets import ArtistLegalProfileQuerySet
+
+IDENTITY_VERIFICATION_REQUIRED_FIELDS = (
+    'last_name',
+    'first_name',
+    'birth_date',
+    'registration_address',
+    'passport_series',
+    'passport_number',
+    'passport_issued_by',
+    'passport_issue_date',
+    'inn',
+)
+
+COMPANY_VERIFICATION_REQUIRED_FIELDS = (
+    'company_name',
+    'company_address',
+    'inn',
+    'ogrn',
+)
+
+BANK_VERIFICATION_REQUIRED_FIELDS = (
+    'bik',
+    'checking_account',
+)
 
 
 class ArtistLegalProfile(TimestampModel):
@@ -70,6 +91,11 @@ class ArtistLegalProfile(TimestampModel):
         blank=True,
     )
 
+    @property
+    def is_ready_for_verification(self):
+        """Показывает, достаточно ли данных для ручной проверки."""
+        return not self.get_verification_missing_fields()
+
     class Meta:
         verbose_name = 'юридический профиль артиста'
         verbose_name_plural = 'юридические профили артистов'
@@ -83,6 +109,74 @@ class ArtistLegalProfile(TimestampModel):
     def save(self, *args, **kwargs):
         self.full_clean()
         super().save(*args, **kwargs)
+
+    def get_verification_missing_fields(self):
+        """Возвращает незаполненные поля, необходимые для проверки."""
+        missing_fields = []
+
+        if not self.recipient_type:
+            missing_fields.append('recipient_type')
+
+        bank_data = getattr(self, 'bank_data', None)
+        missing_fields.extend(
+            self._get_missing_related_fields(
+                bank_data,
+                BANK_VERIFICATION_REQUIRED_FIELDS,
+                'bank_data',
+            ),
+        )
+
+        if self.recipient_type in (
+            self.RecipientType.SELF_EMPLOYED,
+            self.RecipientType.INDIVIDUAL_ENTREPRENEUR,
+        ):
+            identity_data = getattr(self, 'identity_data', None)
+            missing_fields.extend(
+                self._get_missing_related_fields(
+                    identity_data,
+                    IDENTITY_VERIFICATION_REQUIRED_FIELDS,
+                    'identity_data',
+                ),
+            )
+
+        elif self.recipient_type == self.RecipientType.LEGAL_ENTITY:
+            company_data = getattr(self, 'company_data', None)
+            missing_fields.extend(
+                self._get_missing_related_fields(
+                    company_data,
+                    COMPANY_VERIFICATION_REQUIRED_FIELDS,
+                    'company_data',
+                ),
+            )
+
+        return missing_fields
+
+    @staticmethod
+    def _get_missing_related_fields(instance, fields, prefix) -> list:
+        """Возвращает незаполненные обязательные поля связанного объекта."""
+        if instance is None:
+            return [f'{prefix}.{field}' for field in fields]
+
+        missing_fields = []
+
+        for field in fields:
+            value = getattr(instance, field)
+
+            if ArtistLegalProfile._is_empty_value(value):
+                missing_fields.append(f'{prefix}.{field}')
+
+        return missing_fields
+
+    @staticmethod
+    def _is_empty_value(value) -> bool:
+        """Проверяет, считается ли значение незаполненным."""
+        if value is None:
+            return True
+
+        if isinstance(value, str):
+            return not value.strip()
+
+        return False
 
     def __str__(self):
         return f'Юридический профиль: {self.user.username}'

--- a/users/serializers/artist_legal_profile.py
+++ b/users/serializers/artist_legal_profile.py
@@ -64,6 +64,9 @@ class ArtistLegalProfileSerializer(serializers.ModelSerializer):
     is_verified = serializers.BooleanField(read_only=True)
     comment = serializers.CharField(read_only=True)
 
+    is_ready_for_verification = serializers.BooleanField(read_only=True)
+    verification_missing_fields = serializers.SerializerMethodField()
+
     class Meta:
         model = ArtistLegalProfile
         fields = (
@@ -71,8 +74,14 @@ class ArtistLegalProfileSerializer(serializers.ModelSerializer):
             'phone',
             'recipient_type',
             'is_verified',
+            'is_ready_for_verification',
+            'verification_missing_fields',
             'comment',
         )
+
+    def get_verification_missing_fields(self, obj):
+        """Возвращает незаполненные поля, необходимые для проверки."""
+        return obj.get_verification_missing_fields()
 
 
 class ArtistLegalSerializer(serializers.Serializer):
@@ -152,21 +161,3 @@ class ArtistLegalSerializer(serializers.Serializer):
             instance.save(update_fields=('is_verified',))
 
         return instance
-
-    def validate(self, attrs) -> dict:
-        recipient_type = attrs.get(
-            'recipient_type',
-            getattr(self.instance, 'recipient_type', None),
-        )
-        company_data = attrs.get('company_data')
-        if (
-            recipient_type != ArtistLegalProfile.RecipientType.LEGAL_ENTITY
-            and company_data is not None
-        ):
-            raise serializers.ValidationError({
-                'company_data': (
-                    'Данные юридического лица допустимы только '
-                    'для получателя типа "Юридическое лицо".'
-                ),
-            })
-        return attrs

--- a/users/serializers/artist_legal_profile.py
+++ b/users/serializers/artist_legal_profile.py
@@ -1,6 +1,7 @@
 """Сериализаторы юр профиля."""
 
 from django.db import transaction
+from drf_spectacular.utils import extend_schema_field
 from phonenumber_field.serializerfields import PhoneNumberField
 from rest_framework import serializers
 
@@ -79,6 +80,11 @@ class ArtistLegalProfileSerializer(serializers.ModelSerializer):
             'comment',
         )
 
+    @extend_schema_field(
+        serializers.ListField(
+            child=serializers.CharField(),
+        ),
+    )
     def get_verification_missing_fields(self, obj):
         """Возвращает незаполненные поля, необходимые для проверки."""
         return obj.get_verification_missing_fields()

--- a/users/tests/test_artist_legal_profile_api.py
+++ b/users/tests/test_artist_legal_profile_api.py
@@ -580,3 +580,123 @@ class TestArtistLegalProfilePatchRules:
         assert legal_profile.is_verified is old_is_verified
         assert response.data['legal_profile']['comment'] == old_comment
         assert legal_profile.comment == old_comment
+
+
+class TestArtistLegalProfileVerificationReadiness:
+    """Тесты готовности юридического профиля к проверке."""
+
+    def test_empty_profile_returns_all_required_common_fields(
+        self,
+        artist_user,
+    ):
+        legal_profile = ArtistLegalProfile.objects.create(
+            user=artist_user,
+        )
+
+        missing_fields = legal_profile.get_verification_missing_fields()
+
+        assert 'recipient_type' in missing_fields
+        assert 'bank_data.bik' in missing_fields
+        assert 'bank_data.checking_account' in missing_fields
+
+    def test_self_employed_requires_identity_and_bank_data(
+        self,
+        artist_user,
+    ):
+        legal_profile = ArtistLegalProfile.objects.create(
+            user=artist_user,
+            recipient_type=ArtistLegalProfile.RecipientType.SELF_EMPLOYED,
+        )
+
+        missing_fields = legal_profile.get_verification_missing_fields()
+
+        assert 'identity_data.first_name' in missing_fields
+        assert 'identity_data.last_name' in missing_fields
+        assert 'identity_data.passport_number' in missing_fields
+        assert 'bank_data.bik' in missing_fields
+        assert 'company_data.inn' not in missing_fields
+
+    def test_individual_entrepreneur_requires_identity_data(
+        self,
+        artist_user,
+    ):
+        legal_profile = ArtistLegalProfile.objects.create(
+            user=artist_user,
+            recipient_type=(
+                ArtistLegalProfile.RecipientType.INDIVIDUAL_ENTREPRENEUR
+            ),
+        )
+
+        missing_fields = legal_profile.get_verification_missing_fields()
+
+        assert 'identity_data.inn' in missing_fields
+        assert 'company_data.inn' not in missing_fields
+
+    def test_legal_entity_requires_company_data(
+        self,
+        artist_user,
+    ):
+        legal_profile = ArtistLegalProfile.objects.create(
+            user=artist_user,
+            recipient_type=ArtistLegalProfile.RecipientType.LEGAL_ENTITY,
+        )
+
+        missing_fields = legal_profile.get_verification_missing_fields()
+
+        assert 'company_data.company_name' in missing_fields
+        assert 'company_data.inn' in missing_fields
+        assert 'company_data.ogrn' in missing_fields
+        assert 'identity_data.passport_number' not in missing_fields
+
+    def test_middle_name_is_not_required(
+        self,
+        artist_user,
+        artist_legal_profile_factory,
+    ):
+        legal_profile = artist_legal_profile_factory(user=artist_user)
+        legal_profile.identity_data.middle_name = ''
+        legal_profile.identity_data.save()
+
+        assert 'identity_data.middle_name' not in (
+            legal_profile.get_verification_missing_fields()
+        )
+
+    def test_bank_name_and_correspondent_account_are_not_required(
+        self,
+        artist_user,
+        artist_legal_profile_factory,
+    ):
+        legal_profile = artist_legal_profile_factory(user=artist_user)
+        legal_profile.bank_data.bank_name = ''
+        legal_profile.bank_data.correspondent_account = ''
+        legal_profile.bank_data.save()
+
+        missing_fields = legal_profile.get_verification_missing_fields()
+
+        assert 'bank_data.bank_name' not in missing_fields
+        assert 'bank_data.correspondent_account' not in missing_fields
+        assert legal_profile.is_ready_for_verification is True
+
+    def test_complete_self_employed_profile_is_ready(
+        self,
+        artist_user,
+        artist_legal_profile_factory,
+    ):
+        legal_profile = artist_legal_profile_factory(user=artist_user)
+
+        assert legal_profile.get_verification_missing_fields() == []
+        assert legal_profile.is_ready_for_verification is True
+
+    def test_complete_legal_entity_profile_is_ready(
+        self,
+        artist_user,
+        artist_legal_profile_factory,
+    ):
+        legal_profile = artist_legal_profile_factory(
+            user=artist_user,
+            recipient_type=ArtistLegalProfile.RecipientType.LEGAL_ENTITY,
+            with_company_data=True,
+        )
+
+        assert legal_profile.get_verification_missing_fields() == []
+        assert legal_profile.is_ready_for_verification is True


### PR DESCRIPTION
В админку добавлено создание legal_profile.
Селекторы заменены на автокомплит.

Убран запрет иметь одноврменно comany_data и identity_data.
Флаг is_ready_to_verification. Фильтр по нему.