### PR TITLE
feat/590-legal-profile-with-artist

### DIFF
--- a/common/services/ready_for_sales.py
+++ b/common/services/ready_for_sales.py
@@ -14,6 +14,18 @@ class PublicationRequirement(StrEnum):
     LEGAL_PROFILE_VERIFICATION = 'legal_profile_verification'
     SHIPPING_POINT = 'shipping_point'
 
+    @property
+    def description(self) -> str:
+        """Возвращает человекочитаемое описание причины."""
+        descriptions = {
+            self.EMAIL_VERIFICATION: 'не подтверждён email',
+            self.LEGAL_PROFILE_VERIFICATION: (
+                'не подтверждены юридические данные'
+            ),
+            self.SHIPPING_POINT: 'не настроен ПВЗ / СДЭК',
+        }
+        return descriptions[self]
+
 
 @dataclass(frozen=True)
 class ArtistPublicationReadiness:

--- a/users/admin/artist.py
+++ b/users/admin/artist.py
@@ -6,6 +6,8 @@ from django.contrib import admin
 from django.urls import reverse
 from django.utils.html import format_html, format_html_join
 
+from common.services import get_artist_publication_readiness
+
 from users.admin.mixins import ImagePreviewMixin
 from users.models import (
     ArtistContact,
@@ -83,10 +85,10 @@ class ArtistProfileAdmin(ImagePreviewMixin, admin.ModelAdmin):
         'user',
         'city',
         'is_active',
-        'payout_legal_profile_verified',
+        'sales_readiness',
         'created_at',
     )
-    list_display_links = ('id', 'name', 'user')
+    list_display_links = ('id', 'name')
     list_filter = (
         'profile_type',
         'is_active',
@@ -96,7 +98,11 @@ class ArtistProfileAdmin(ImagePreviewMixin, admin.ModelAdmin):
         'account_phone',
         'account_username',
         'user_link',
+        'sales_ready',
+        'digital_sales_ready',
+        'physical_sales_ready',
         'payout_legal_profile_verified',
+        'shipping_point_ready',
         'payout_legal_profile_link',
         'managed_artists',
         'image_preview',
@@ -162,9 +168,56 @@ class ArtistProfileAdmin(ImagePreviewMixin, admin.ModelAdmin):
             obj.user.email,
         )
 
+    @admin.display(description='Продажи')
+    def sales_readiness(self, obj):
+        readiness = get_artist_publication_readiness(obj)
+
+        if readiness.can_publish_physical:
+            return 'Все типы'
+
+        if readiness.can_publish_digital:
+            return 'Цифровые'
+
+        return 'Не готов'
+
+    @admin.display(description='Готов к продажам', boolean=True)
+    def sales_ready(self, obj):
+        readiness = get_artist_publication_readiness(obj)
+        return readiness.can_publish_digital
+
+    @admin.display(description='Цифровые продажи')
+    def digital_sales_ready(self, obj):
+        readiness = get_artist_publication_readiness(obj)
+
+        if readiness.can_publish_digital:
+            return 'Доступны'
+
+        return ', '.join(
+            requirement.description
+            for requirement in readiness.digital_missing
+        )
+
+    @admin.display(description='Физические продажи')
+    def physical_sales_ready(self, obj):
+        readiness = get_artist_publication_readiness(obj)
+
+        if readiness.can_publish_physical:
+            return 'Доступны'
+
+        return ', '.join(
+            requirement.description
+            for requirement in readiness.physical_missing
+        )
+
+    @admin.display(description='ПВЗ / СДЭК настроен', boolean=True)
+    def shipping_point_ready(self, obj):
+        return obj.effective_shipping_point is not None
+
     @admin.display(description='Юр. данные подтверждены', boolean=True)
     def payout_legal_profile_verified(self, obj):
-        legal_profile = obj.default_payout_recipient.legal_profile
+        payout_recipient = obj.default_payout_recipient
+        legal_profile = getattr(payout_recipient, 'legal_profile', None)
+
         return bool(legal_profile and legal_profile.is_verified)
 
     @admin.display(description='Юридический профиль получателя выплат')
@@ -299,8 +352,6 @@ class ArtistProfileAdmin(ImagePreviewMixin, admin.ModelAdmin):
                 'account_username',
                 'account_phone',
                 'display_connect_to_telegram',
-                'payout_legal_profile_verified',
-                'payout_legal_profile_link',
             ]
 
             if obj.profile_type == ArtistProfileType.LABEL:
@@ -312,6 +363,22 @@ class ArtistProfileAdmin(ImagePreviewMixin, admin.ModelAdmin):
                     'Тип и управление',
                     {
                         'fields': tuple(management_fields),
+                    },
+                ),
+            )
+            fieldsets.insert(
+                1,
+                (
+                    'Доступ к продажам',
+                    {
+                        'fields': (
+                            'sales_ready',
+                            'digital_sales_ready',
+                            'physical_sales_ready',
+                            'payout_legal_profile_verified',
+                            'shipping_point_ready',
+                            'payout_legal_profile_link',
+                        ),
                     },
                 ),
             )

--- a/users/admin/artist.py
+++ b/users/admin/artist.py
@@ -83,6 +83,7 @@ class ArtistProfileAdmin(ImagePreviewMixin, admin.ModelAdmin):
         'user',
         'city',
         'is_active',
+        'payout_legal_profile_verified',
         'created_at',
     )
     list_display_links = ('id', 'name', 'user')
@@ -95,6 +96,7 @@ class ArtistProfileAdmin(ImagePreviewMixin, admin.ModelAdmin):
         'account_phone',
         'account_username',
         'user_link',
+        'payout_legal_profile_verified',
         'payout_legal_profile_link',
         'managed_artists',
         'image_preview',
@@ -159,6 +161,11 @@ class ArtistProfileAdmin(ImagePreviewMixin, admin.ModelAdmin):
             url,
             obj.user.email,
         )
+
+    @admin.display(description='Юр. данные подтверждены', boolean=True)
+    def payout_legal_profile_verified(self, obj):
+        legal_profile = obj.default_payout_recipient.legal_profile
+        return bool(legal_profile and legal_profile.is_verified)
 
     @admin.display(description='Юридический профиль получателя выплат')
     def payout_legal_profile_link(self, obj):
@@ -292,6 +299,7 @@ class ArtistProfileAdmin(ImagePreviewMixin, admin.ModelAdmin):
                 'account_username',
                 'account_phone',
                 'display_connect_to_telegram',
+                'payout_legal_profile_verified',
                 'payout_legal_profile_link',
             ]
 

--- a/users/admin/artist.py
+++ b/users/admin/artist.py
@@ -1,5 +1,7 @@
 """Модуль админки профиля артиста."""
 
+from urllib.parse import urlencode
+
 from django.contrib import admin
 from django.urls import reverse
 from django.utils.html import format_html, format_html_join
@@ -93,6 +95,7 @@ class ArtistProfileAdmin(ImagePreviewMixin, admin.ModelAdmin):
         'account_phone',
         'account_username',
         'user_link',
+        'payout_legal_profile_link',
         'managed_artists',
         'image_preview',
         'created_at',
@@ -128,7 +131,7 @@ class ArtistProfileAdmin(ImagePreviewMixin, admin.ModelAdmin):
             return '—'
 
         return format_html_join(
-            '<br>',
+            ', ',
             '<a href="{}">{}</a>',
             (
                 (
@@ -155,6 +158,67 @@ class ArtistProfileAdmin(ImagePreviewMixin, admin.ModelAdmin):
             '<a href="{}">{}</a>',
             url,
             obj.user.email,
+        )
+
+    @admin.display(description='Юридический профиль получателя выплат')
+    def payout_legal_profile_link(self, obj):
+        if not obj or not obj.pk:
+            return '—'
+
+        # Для управляемого артиста получателем является лейбл.
+        if obj.profile_type == ArtistProfileType.ARTIST and obj.label_id:
+            label = obj.label
+            label_url = reverse(
+                'admin:users_artistprofile_change',
+                args=(label.pk,),
+            )
+
+            if not label.user_id:
+                return format_html(
+                    'У лейбла нет учётной записи — '
+                    '<a href="{}">перейти к профилю лейбла</a>',
+                    label_url,
+                )
+
+            legal_profile = getattr(label.user, 'legal_profile', None)
+
+            if not legal_profile:
+                return format_html(
+                    'Не создан — <a href="{}">перейти к профилю лейбла</a>',
+                    label_url,
+                )
+
+            legal_profile_url = reverse(
+                'admin:users_artistlegalprofile_change',
+                args=(legal_profile.pk,),
+            )
+            return format_html(
+                '<a href="{}">Юридический профиль лейбла «{}»</a>',
+                legal_profile_url,
+                label.name,
+            )
+
+        if not obj.user_id:
+            return 'Учётная запись не настроена'
+
+        legal_profile = getattr(obj.user, 'legal_profile', None)
+
+        if legal_profile:
+            url = reverse(
+                'admin:users_artistlegalprofile_change',
+                args=(legal_profile.pk,),
+            )
+            return format_html(
+                '<a href="{}">Открыть юридический профиль</a>',
+                url,
+            )
+
+        url = reverse('admin:users_artistlegalprofile_add')
+        url = f'{url}?{urlencode({"user": obj.user_id})}'
+
+        return format_html(
+            '<a href="{}">Не создан. Создать?</a>',
+            url,
         )
 
     @admin.display(description='Телефон учетной записи')
@@ -228,6 +292,7 @@ class ArtistProfileAdmin(ImagePreviewMixin, admin.ModelAdmin):
                 'account_username',
                 'account_phone',
                 'display_connect_to_telegram',
+                'payout_legal_profile_link',
             ]
 
             if obj.profile_type == ArtistProfileType.LABEL:

--- a/users/admin/artist_legal_profile.py
+++ b/users/admin/artist_legal_profile.py
@@ -308,6 +308,9 @@ class ArtistLegalProfileAdmin(admin.ModelAdmin):
         if obj:
             readonly_fields.append('user')
 
+            if obj is None or not obj.is_ready_for_verification:
+                readonly_fields.append('is_verified')
+
         return readonly_fields
 
     def _get_verification_field_label(self, field_name) -> str:
@@ -319,3 +322,13 @@ class ArtistLegalProfileAdmin(admin.ModelAdmin):
         model = VERIFICATION_MODELS[prefix]
 
         return model._meta.get_field(related_field).verbose_name
+
+    def save_related(self, request, form, formsets, change):
+        """Сбрасывает подтверждение при неполных юридических данных."""
+        super().save_related(request, form, formsets, change)
+
+        obj = form.instance
+
+        if obj.is_verified and not obj.is_ready_for_verification:
+            obj.is_verified = False
+            obj.save(update_fields=('is_verified',))

--- a/users/admin/artist_legal_profile.py
+++ b/users/admin/artist_legal_profile.py
@@ -308,8 +308,8 @@ class ArtistLegalProfileAdmin(admin.ModelAdmin):
         if obj:
             readonly_fields.append('user')
 
-            if obj is None or not obj.is_ready_for_verification:
-                readonly_fields.append('is_verified')
+        if obj is None or not obj.is_ready_for_verification:
+            readonly_fields.append('is_verified')
 
         return readonly_fields
 

--- a/users/admin/user.py
+++ b/users/admin/user.py
@@ -5,9 +5,13 @@ inlines для слушателя и артиста.
 Добавлены флаги наличия профиля артиста и слушателя.
 """
 
+from urllib.parse import urlencode
+
 from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin
+from django.urls import reverse
+from django.utils.html import format_html
 
 from users.admin.mixins import ImagePreviewMixin
 from users.models import (
@@ -76,6 +80,31 @@ class CoreUserAdmin(UserAdmin):
         """Есть ли профиль артиста."""
         return hasattr(obj, 'artist_profile')
 
+    @admin.display(description='Юридический профиль')
+    def legal_profile_link(self, obj):
+        if not obj or not obj.pk:
+            return '—'
+
+        legal_profile = getattr(obj, 'legal_profile', None)
+
+        if legal_profile:
+            url = reverse(
+                'admin:users_artistlegalprofile_change',
+                args=(legal_profile.pk,),
+            )
+            return format_html(
+                '<a href="{}">Открыть юридический профиль</a>',
+                url,
+            )
+
+        url = reverse('admin:users_artistlegalprofile_add')
+        url = f'{url}?{urlencode({"user": obj.pk})}'
+
+        return format_html(
+            '<a href="{}">Не создан. Создать?</a>',
+            url,
+        )
+
     def save_related(self, request, form, formsets, change):
         """Сохраняет inlines и гарантирует наличие профиля слушателя."""
         super().save_related(request, form, formsets, change)
@@ -118,7 +147,11 @@ class CoreUserAdmin(UserAdmin):
         (
             'Подтверждение контактов',
             {
-                'fields': ('is_email_verified', 'is_phone_verified'),
+                'fields': (
+                    'is_email_verified',
+                    'is_phone_verified',
+                    'legal_profile_link',
+                ),
             },
         ),
         (

--- a/users/admin/user.py
+++ b/users/admin/user.py
@@ -150,8 +150,13 @@ class CoreUserAdmin(UserAdmin):
                 'fields': (
                     'is_email_verified',
                     'is_phone_verified',
-                    'legal_profile_link',
                 ),
+            },
+        ),
+        (
+            'Юридические данные',
+            {
+                'fields': ('legal_profile_link',),
             },
         ),
         (
@@ -174,7 +179,11 @@ class CoreUserAdmin(UserAdmin):
             },
         ),
     )
-    readonly_fields = ('last_login', 'date_joined')
+    readonly_fields = (
+        'last_login',
+        'date_joined',
+        'legal_profile_link',
+    )
     add_fieldsets = (
         (
             None,

--- a/users/models/artist/profile.py
+++ b/users/models/artist/profile.py
@@ -229,6 +229,29 @@ class ArtistProfile(ActivatableModel, TimestampModel):
         """Проверяет корректность связи артиста с лейблом."""
         super().clean()
 
+        if self.profile_type == ArtistProfileType.LABEL:
+            if self.user_id is None:
+                raise ValidationError({
+                    'profile_type': (
+                        'Профиль лейбла должен быть связан с учётной записью.'
+                    ),
+                })
+
+            if self.label_id is not None:
+                raise ValidationError({
+                    'label': 'Профиль лейбла не может состоять в лейбле.',
+                })
+
+            return
+
+        if self.user_id is None and self.label_id is None:
+            raise ValidationError({
+                'label': (
+                    'Артист без собственной учётной записи '
+                    'должен быть связан с лейблом.'
+                ),
+            })
+
         if self.label_id is None:
             return
 


### PR DESCRIPTION
- управляемые артисты теперь отображаются правильно.
- готовность артиста к цифровым/физическим продажам с причинами недоступности;
- ссылки на юрпрофиль из артиста и учётной записи;
- запрещено подтверждение неполного юрпрофиля;
- доп валидация состояний артист/лейбл;