### PR TITLE
fix/is_available_for_purchase-fixed-for-track

### DIFF
--- a/store/models/product_variant.py
+++ b/store/models/product_variant.py
@@ -111,12 +111,21 @@ class ProductVariant(ActivatableModel, TimestampModel):
         if not content.is_active:
             return False
 
-        if not content.is_published:
+        publication_content = (
+            content.album
+            if product.product_type == product.ProductType.TRACK
+            else content
+        )
+
+        if not publication_content.is_active:
             return False
 
-        if content.visibility not in (
-            content.Visibility.PUBLIC,
-            content.Visibility.LINK_ONLY,
+        if not publication_content.is_published:
+            return False
+
+        if publication_content.visibility not in (
+            publication_content.Visibility.PUBLIC,
+            publication_content.Visibility.LINK_ONLY,
         ):
             return False
 

--- a/store/tests/test_cart_api.py
+++ b/store/tests/test_cart_api.py
@@ -9,6 +9,11 @@ from rest_framework.response import Response
 
 from store.models import Cart, CartItem
 
+pytestmark = [
+    pytest.mark.django_db,
+    pytest.mark.usefixtures('publication_readiness_disabled'),
+]
+
 
 class TestCartAPI:
     """Набор тестов для проверки функциональности корзины покупок."""

--- a/store/tests/test_checkout_api.py
+++ b/store/tests/test_checkout_api.py
@@ -7,6 +7,11 @@ from store.models import CartItem, Order, OrderItem
 from users.models import ConsentDocument, UserConsent
 from users.tests.factories import ArtistProfileFactory, LabelProfileFactory
 
+pytestmark = [
+    pytest.mark.django_db,
+    pytest.mark.usefixtures('publication_readiness_disabled'),
+]
+
 
 @pytest.mark.django_db
 class TestCheckoutAPI:

--- a/store/tests/test_promocode_api.py
+++ b/store/tests/test_promocode_api.py
@@ -6,6 +6,11 @@ from rest_framework import status
 
 from store.models import Cart, Promocode
 
+pytestmark = [
+    pytest.mark.django_db,
+    pytest.mark.usefixtures('publication_readiness_disabled'),
+]
+
 
 class TestPromocodeAPI:
     """Набор тестов для логики промокодов в корзине."""


### PR DESCRIPTION
is_available_for_purchase корректно обрабатывает трек.
В тестах корзины, скидкакода и чакаута временно заглушено требование готовности продавца.