### PR TITLE
fix/social-consents

### DIFF
--- a/users/services/consent.py
+++ b/users/services/consent.py
@@ -26,6 +26,7 @@ class ConsentService:
         user_agent: str = '',
         order=None,
         artist=None,
+        skip_existing: bool = False,
     ) -> None:
         """Фиксирует принятые пользователем согласия."""
         accepted_types = set(accepted_types)
@@ -57,7 +58,25 @@ class ConsentService:
                 ),
             })
 
+        existing_document_ids = set()
+
+        if skip_existing and user is not None:
+            existing_document_ids = set(
+                UserConsent.objects.filter(
+                    user=user,
+                    document__in=documents_by_type.values(),
+                    revoked_at__isnull=True,
+                ).values_list(
+                    'document_id',
+                    flat=True,
+                ),
+            )
+
         for document_type in accepted_types:
+            document = documents_by_type[document_type]
+            if document.id in existing_document_ids:
+                continue
+
             UserConsent.objects.create(
                 user=user,
                 email=email,

--- a/users/services/social_auth.py
+++ b/users/services/social_auth.py
@@ -82,6 +82,13 @@ class SocialAuthService:
                 email=email,
                 is_email_verified=is_email_verified,
             )
+            self._accept_registration_consents(
+                user=user,
+                create_account=create_account,
+                accepted_consents=accepted_consents,
+                ip_address=ip_address,
+                user_agent=user_agent,
+            )
             return user
 
         if not email:
@@ -107,6 +114,14 @@ class SocialAuthService:
                     SOCIAL_AUTH_ERROR_EMAIL_NOT_CONFIRMED,
                     SOCIAL_AUTH_ERRORS[SOCIAL_AUTH_ERROR_EMAIL_NOT_CONFIRMED],
                 )
+
+            self._accept_registration_consents(
+                user=existing_user,
+                create_account=create_account,
+                accepted_consents=accepted_consents,
+                ip_address=ip_address,
+                user_agent=user_agent,
+            )
 
             return existing_user
 
@@ -202,3 +217,26 @@ class SocialAuthService:
                 SOCIAL_AUTH_ERROR_BLOCKED_USER,
                 SOCIAL_AUTH_ERRORS[SOCIAL_AUTH_ERROR_BLOCKED_USER],
             )
+
+    def _accept_registration_consents(
+        self,
+        *,
+        user,
+        create_account: bool,
+        accepted_consents,
+        ip_address: str | None,
+        user_agent: str,
+    ) -> None:
+        """Фиксирует согласия при входе с флагом регистрации."""
+        if not create_account:
+            return
+
+        ConsentService.accept(
+            scenario=ConsentScenario.LISTENER_REGISTRATION,
+            accepted_types=accepted_consents,
+            user=user,
+            email=user.email,
+            ip_address=ip_address,
+            user_agent=user_agent,
+            skip_existing=True,
+        )

--- a/users/tests/test_social_auth.py
+++ b/users/tests/test_social_auth.py
@@ -20,7 +20,7 @@ from users.constants import (
     SOCIAL_AUTH_ERROR_SOCIAL_SAVE_FAILED,
 )
 from users.exceptions import SocialAuthException
-from users.models import ListenerProfile, UserConsent
+from users.models import ConsentDocument, ListenerProfile, UserConsent
 from users.services import SocialAuthService
 from users.tests.factories import UserFactory
 
@@ -317,6 +317,192 @@ class TestSocialAuthService:
         )
 
         assert saved_types == set(listener_registration_consents)
+
+    @override_settings(CONSENT_ENFORCE_REQUIRED=True)
+    def test_existing_user_accepts_consents_from_registration_flow(
+        self,
+        listener_registration_consents,
+    ):
+        """Сохраняет согласия существующему user с формы регистрации."""
+        user = UserFactory(
+            email='listener@example.test',
+            is_email_verified=True,
+        )
+
+        resolved_user = SocialAuthService().resolve_user(
+            provider=YANDEX_PROVIDER,
+            provider_uid='yandex-1012',
+            email=user.email,
+            is_email_verified=True,
+            create_account=True,
+            accepted_consents=listener_registration_consents,
+        )
+
+        saved_types = set(
+            UserConsent.objects.filter(
+                user=user,
+                revoked_at__isnull=True,
+            ).values_list(
+                'document__document_type',
+                flat=True,
+            ),
+        )
+
+        assert resolved_user.pk == user.pk
+        assert saved_types == set(listener_registration_consents)
+
+    @override_settings(CONSENT_ENFORCE_REQUIRED=True)
+    def test_existing_social_user_does_not_duplicate_current_consents(
+        self,
+        listener_registration_consents,
+    ):
+        """Не дублирует согласия на уже принятую актуальную версию."""
+        user = UserFactory(
+            email='listener@example.test',
+            is_email_verified=True,
+        )
+        SocialAccount.objects.create(
+            user=user,
+            provider=YANDEX_PROVIDER,
+            uid='yandex-1013',
+            extra_data={},
+        )
+
+        service = SocialAuthService()
+
+        service.resolve_user(
+            provider=YANDEX_PROVIDER,
+            provider_uid='yandex-1013',
+            email=user.email,
+            is_email_verified=True,
+            create_account=True,
+            accepted_consents=listener_registration_consents,
+        )
+
+        first_count = UserConsent.objects.filter(user=user).count()
+
+        service.resolve_user(
+            provider=YANDEX_PROVIDER,
+            provider_uid='yandex-1013',
+            email=user.email,
+            is_email_verified=True,
+            create_account=True,
+            accepted_consents=listener_registration_consents,
+        )
+
+        assert first_count == len(listener_registration_consents)
+        assert UserConsent.objects.filter(user=user).count() == first_count
+
+    @override_settings(CONSENT_ENFORCE_REQUIRED=True)
+    def test_existing_user_accepts_new_document_version(
+        self,
+        listener_registration_consents,
+    ):
+        """Сохраняет согласие на новую актуальную версию документа."""
+        user = UserFactory(
+            email='listener@example.test',
+            is_email_verified=True,
+        )
+        service = SocialAuthService()
+
+        service.resolve_user(
+            provider=YANDEX_PROVIDER,
+            provider_uid='yandex-1014',
+            email=user.email,
+            is_email_verified=True,
+            create_account=True,
+            accepted_consents=listener_registration_consents,
+        )
+
+        document_type = listener_registration_consents[0]
+
+        old_document = ConsentDocument.objects.get(
+            document_type=document_type,
+            is_active=True,
+        )
+        old_document.is_active = False
+        old_document.save(update_fields=('is_active',))
+
+        new_document = ConsentDocument.objects.create(
+            document_type=document_type,
+            version='2.0',
+            content=f'Новая версия документа: {document_type}',
+            is_active=True,
+        )
+
+        service.resolve_user(
+            provider=YANDEX_PROVIDER,
+            provider_uid='yandex-1014',
+            email=user.email,
+            is_email_verified=True,
+            create_account=True,
+            accepted_consents=listener_registration_consents,
+        )
+
+        assert (
+            UserConsent.objects.filter(
+                user=user,
+                document=old_document,
+                revoked_at__isnull=True,
+            ).count()
+            == 1
+        )
+        assert (
+            UserConsent.objects.filter(
+                user=user,
+                document=new_document,
+                revoked_at__isnull=True,
+            ).count()
+            == 1
+        )
+
+    @override_settings(CONSENT_ENFORCE_REQUIRED=True)
+    def test_existing_user_registration_requires_all_consents(
+        self,
+        listener_registration_consents,
+    ):
+        """Проверяет обязательные согласия и для существующего user."""
+        user = UserFactory(
+            email='listener@example.test',
+            is_email_verified=True,
+        )
+
+        incomplete_consents = listener_registration_consents[:-1]
+
+        with pytest.raises(ValidationError):
+            SocialAuthService().resolve_user(
+                provider=YANDEX_PROVIDER,
+                provider_uid='yandex-1015',
+                email=user.email,
+                is_email_verified=True,
+                create_account=True,
+                accepted_consents=incomplete_consents,
+            )
+
+        assert not UserConsent.objects.filter(user=user).exists()
+
+    @override_settings(CONSENT_ENFORCE_REQUIRED=True)
+    def test_existing_user_login_does_not_save_passed_consents(
+        self,
+        listener_registration_consents,
+    ):
+        """Не меняет согласия при обычном входе без флага регистрации."""
+        user = UserFactory(
+            email='listener@example.test',
+            is_email_verified=True,
+        )
+
+        resolved_user = SocialAuthService().resolve_user(
+            provider=YANDEX_PROVIDER,
+            provider_uid='yandex-1016',
+            email=user.email,
+            is_email_verified=True,
+            create_account=False,
+            accepted_consents=listener_registration_consents,
+        )
+
+        assert resolved_user.pk == user.pk
+        assert not UserConsent.objects.filter(user=user).exists()
 
 
 class TestSocialAccountAdapter:


### PR DESCRIPTION
При social auth с create_account=true существующему пользователю обновляются переданные согласия, если существующие устарели