### PR TITLE
fix/650-artist-deactivation

### DIFF
--- a/store/querysets/product.py
+++ b/store/querysets/product.py
@@ -56,6 +56,7 @@ class ProductQuerySet(models.QuerySet):
             track__isnull=False,
             track__is_active=True,
             track__album__is_active=True,
+            track__album__artist__is_active=True,
             track__album__is_published=True,
             track__album__visibility='public',
         )
@@ -66,6 +67,7 @@ class ProductQuerySet(models.QuerySet):
             digital_publication_ready_q('album__'),
             album__isnull=False,
             album__is_active=True,
+            album__artist__is_active=True,
             album__is_published=True,
             album__visibility='public',
         )
@@ -76,6 +78,7 @@ class ProductQuerySet(models.QuerySet):
             physical_publication_ready_q('merch__'),
             merch__isnull=False,
             merch__is_active=True,
+            merch__artist__is_active=True,
             merch__is_published=True,
             merch__visibility='public',
             has_available_variant=True,
@@ -90,6 +93,7 @@ class ProductQuerySet(models.QuerySet):
         album_q = models.Q(
             album__isnull=False,
             album__is_active=True,
+            album__artist__is_active=True,
             album__is_published=True,
             album__visibility='public',
         ) & digital_publication_ready_q('album__')
@@ -97,6 +101,7 @@ class ProductQuerySet(models.QuerySet):
         merch_q = models.Q(
             merch__isnull=False,
             merch__is_active=True,
+            merch__artist__is_active=True,
             merch__is_published=True,
             merch__visibility='public',
             has_available_variant=True,

--- a/store/tests/test_catalog_api.py
+++ b/store/tests/test_catalog_api.py
@@ -44,6 +44,81 @@ class TestCatalogVisibility:
             products['public_album'].id,
         }
 
+    def test_catalog_hides_album_of_inactive_artist(
+        self,
+        api_client,
+        catalog_url,
+    ):
+        """Каталог не возвращает альбом выключенного артиста."""
+        product = create_album_product()
+
+        artist = product.album.artist
+        artist.is_active = False
+        artist.save(update_fields=('is_active',))
+
+        response = api_client.get(catalog_url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert product.id not in get_product_ids(response)
+
+    def test_catalog_hides_merch_of_inactive_artist(
+        self,
+        api_client,
+        catalog_url,
+    ):
+        """Каталог не возвращает мерч выключенного артиста."""
+        product = create_merch_product()
+
+        artist = product.merch.artist
+        artist.is_active = False
+        artist.save(update_fields=('is_active',))
+
+        response = api_client.get(catalog_url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert product.id not in get_product_ids(response)
+
+    def test_inactive_label_does_not_hide_managed_artist_content(
+        self,
+        api_client,
+        catalog_url,
+        variant_factory,
+    ):
+        """Выключение лейбла не скрывает контент его активного артиста."""
+        label = LabelProfileFactory()
+        managed_artist = ArtistProfileFactory(
+            label=label,
+        )
+        variant = variant_factory(
+            product_type='album',
+            artist=managed_artist,
+        )
+
+        label.is_active = False
+        label.save(update_fields=('is_active',))
+
+        response = api_client.get(catalog_url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert variant.product_id in get_product_ids(response)
+
+    def test_catalog_hides_carrier_of_inactive_artist(
+        self,
+        api_client,
+        catalog_url,
+    ):
+        """Каталог не возвращает носитель выключенного артиста."""
+        product = create_carrier_product()
+
+        artist = product.merch.artist
+        artist.is_active = False
+        artist.save(update_fields=('is_active',))
+
+        response = api_client.get(catalog_url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert product.id not in get_product_ids(response)
+
 
 class TestCatalogCardValues:
     """Тесты значений карточек каталога."""

--- a/store/tests/test_catalog_detail_api.py
+++ b/store/tests/test_catalog_detail_api.py
@@ -96,6 +96,24 @@ class TestCatalogReleaseDetail:
             vinyl_product.variants.first().id,
         }
 
+    def test_catalog_release_detail_hides_inactive_artist(
+        self,
+        api_client,
+        catalog_release_detail_url,
+    ):
+        """Detail релиза выключенного артиста недоступен."""
+        product = create_album_product()
+        album = product.album
+
+        album.artist.is_active = False
+        album.artist.save(update_fields=('is_active',))
+
+        response = api_client.get(
+            catalog_release_detail_url(album),
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
 
 class TestCatalogMerchDetail:
     """Тесты detail-ручки обычного мерча."""
@@ -159,3 +177,21 @@ class TestCatalogMerchDetail:
         merch.save(update_fields=('visibility',))
 
         assert variant.is_available_for_purchase is True
+
+    def test_catalog_merch_detail_hides_inactive_artist(
+        self,
+        api_client,
+        catalog_merch_detail_url,
+    ):
+        """Detail мерча выключенного артиста недоступен."""
+        product = create_merch_product()
+        merch = product.merch
+
+        merch.artist.is_active = False
+        merch.artist.save(update_fields=('is_active',))
+
+        response = api_client.get(
+            catalog_merch_detail_url(merch),
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/store/views/catalog.py
+++ b/store/views/catalog.py
@@ -117,6 +117,7 @@ class CatalogReleaseDetailView(RetrieveAPIView):
         carrier_qs = (
             Merch.objects
             .filter(
+                artist__is_active=True,
                 kind__is_carrier=True,
                 is_active=True,
                 is_published=True,
@@ -140,6 +141,7 @@ class CatalogReleaseDetailView(RetrieveAPIView):
         return (
             Album.objects
             .filter(
+                artist__is_active=True,
                 is_published=True,
                 is_active=True,
                 visibility=Album.Visibility.PUBLIC,
@@ -180,6 +182,7 @@ class CatalogMerchDetailView(RetrieveAPIView):
         return (
             Merch.objects
             .filter(
+                artist__is_active=True,
                 is_active=True,
                 is_published=True,
                 visibility=Merch.Visibility.PUBLIC,

--- a/store/views/catalog.py
+++ b/store/views/catalog.py
@@ -117,7 +117,6 @@ class CatalogReleaseDetailView(RetrieveAPIView):
         carrier_qs = (
             Merch.objects
             .filter(
-                artist__is_active=True,
                 kind__is_carrier=True,
                 is_active=True,
                 is_published=True,

--- a/users/serializers/account.py
+++ b/users/serializers/account.py
@@ -81,8 +81,13 @@ class MeSerializer(serializers.ModelSerializer):
         ),
     )
     def get_profile_type(self, obj):
+        """Возвращает тип активного профиля артиста или лейбла."""
         artist_profile = getattr(obj, 'artist_profile', None)
-        return artist_profile.profile_type if artist_profile else None
+
+        if not artist_profile or not artist_profile.is_active:
+            return None
+
+        return artist_profile.profile_type
 
 
 class NewPasswordSerializer(serializers.Serializer):

--- a/users/serializers/account.py
+++ b/users/serializers/account.py
@@ -40,6 +40,7 @@ class MeSerializer(serializers.ModelSerializer):
     is_listener = serializers.SerializerMethodField()
     is_artist = serializers.SerializerMethodField()
     profile_type = serializers.SerializerMethodField()
+    available_profile_upgrades = serializers.SerializerMethodField()
     has_usable_password = serializers.SerializerMethodField()
 
     class Meta:
@@ -54,6 +55,7 @@ class MeSerializer(serializers.ModelSerializer):
             'is_listener',
             'is_artist',
             'profile_type',
+            'available_profile_upgrades',
             'has_usable_password',
         )
 
@@ -88,6 +90,34 @@ class MeSerializer(serializers.ModelSerializer):
             return None
 
         return artist_profile.profile_type
+
+    @extend_schema_field(
+        serializers.ListField(
+            child=serializers.ChoiceField(
+                choices=ArtistProfileType.choices,
+            ),
+        ),
+    )
+    def get_available_profile_upgrades(self, obj):
+        """Возвращает доступные переходы между типами профиля."""
+        artist_profile = getattr(obj, 'artist_profile', None)
+
+        if artist_profile is None:
+            return [
+                ArtistProfileType.ARTIST,
+                ArtistProfileType.LABEL,
+            ]
+
+        if not artist_profile.is_active:
+            return []
+
+        if (
+            artist_profile.profile_type == ArtistProfileType.ARTIST
+            and artist_profile.label_id is None
+        ):
+            return [ArtistProfileType.LABEL]
+
+        return []
 
 
 class NewPasswordSerializer(serializers.Serializer):

--- a/users/tests/test_account.py
+++ b/users/tests/test_account.py
@@ -91,3 +91,69 @@ class TestMeApi:
         assert response.status_code == status.HTTP_200_OK
         assert response.data['is_artist'] is False
         assert response.data['profile_type'] is None
+        assert response.data['available_profile_upgrades'] == []
+
+    def test_listener_has_artist_and_label_profile_upgrades(
+        self,
+        listener_client,
+        account_me_url,
+    ):
+        response = listener_client.get(account_me_url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['available_profile_upgrades'] == [
+            ArtistProfileType.ARTIST,
+            ArtistProfileType.LABEL,
+        ]
+
+    def test_independent_artist_can_upgrade_to_label(
+        self,
+        artist_client,
+        account_me_url,
+    ):
+        response = artist_client.get(account_me_url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['available_profile_upgrades'] == [
+            ArtistProfileType.LABEL,
+        ]
+
+    def test_managed_artist_has_no_profile_upgrades(
+        self,
+        client_factory,
+        signed_artist_user,
+        account_me_url,
+    ):
+        client = client_factory(signed_artist_user)
+
+        response = client.get(account_me_url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['available_profile_upgrades'] == []
+
+    def test_label_has_no_profile_upgrades(
+        self,
+        label_client,
+        account_me_url,
+    ):
+        response = label_client.get(account_me_url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['available_profile_upgrades'] == []
+
+    def test_inactive_artist_has_no_profile_upgrades(
+        self,
+        artist_client,
+        artist_user,
+        account_me_url,
+    ):
+        artist = artist_user.artist_profile
+        artist.is_active = False
+        artist.save(update_fields=('is_active',))
+
+        response = artist_client.get(account_me_url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['is_artist'] is False
+        assert response.data['profile_type'] is None
+        assert response.data['available_profile_upgrades'] == []

--- a/users/tests/test_account.py
+++ b/users/tests/test_account.py
@@ -57,3 +57,37 @@ class TestMeApi:
         response = api_client.get(account_me_url)
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_account_me_does_not_return_inactive_artist_role(
+        self,
+        artist_client,
+        artist_user,
+        account_me_url,
+    ):
+        """Выключенный профиль не считается активной ролью артиста."""
+        artist = artist_user.artist_profile
+        artist.is_active = False
+        artist.save(update_fields=('is_active',))
+
+        response = artist_client.get(account_me_url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['is_artist'] is False
+        assert response.data['profile_type'] is None
+
+    def test_account_me_does_not_return_inactive_label_role(
+        self,
+        label_client,
+        label_user,
+        account_me_url,
+    ):
+        """Выключенный профиль не считается активной ролью лейбла."""
+        label = label_user.artist_profile
+        label.is_active = False
+        label.save(update_fields=('is_active',))
+
+        response = label_client.get(account_me_url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['is_artist'] is False
+        assert response.data['profile_type'] is None

--- a/users/tests/test_profiles.py
+++ b/users/tests/test_profiles.py
@@ -527,6 +527,40 @@ class TestArtistPublicApi:
         assert response.status_code == status.HTTP_200_OK
         assert response.data['profile_type'] == ArtistProfileType.LABEL
 
+    def test_inactive_artist_profile_is_not_available(
+        self,
+        api_client,
+        artist_user,
+        artist_public_url,
+    ):
+        """Публичный профиль выключенного артиста недоступен."""
+        artist = artist_user.artist_profile
+        artist.is_active = False
+        artist.save(update_fields=('is_active',))
+
+        response = api_client.get(
+            artist_public_url(artist),
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_inactive_label_profile_is_not_available(
+        self,
+        api_client,
+        label_user,
+        artist_public_url,
+    ):
+        """Публичный профиль выключенного лейбла недоступен."""
+        label = label_user.artist_profile
+        label.is_active = False
+        label.save(update_fields=('is_active',))
+
+        response = api_client.get(
+            artist_public_url(label),
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
 
 @pytest.mark.usefixtures('publication_readiness_disabled')
 class TestArtistListApi:
@@ -598,6 +632,24 @@ class TestArtistListApi:
         artist_ids = {item['id'] for item in response.data['results']}
 
         assert artist.id in artist_ids
+
+    def test_list_hides_inactive_artist(
+        self,
+        api_client,
+        artist_list_url,
+    ):
+        """Публичный список не содержит выключенного артиста."""
+        artist = ArtistProfileFactory(
+            is_active=False,
+        )
+
+        response = api_client.get(artist_list_url)
+
+        assert response.status_code == HTTPStatus.OK
+
+        artist_ids = {item['id'] for item in response.data['results']}
+
+        assert artist.id not in artist_ids
 
 
 @pytest.mark.usefixtures('publication_readiness_enabled')


### PR DESCRIPTION
Выключение артиста скрывает его товары.
Выключение лейбла скрывает товаары лейбла, на подопечных артистов не влияет автоматически.

accounts/me корректно отдавет тип выключенного профиля.
accounts/me отдает  "available_profile_upgrades": list, чтобы фронт мог показывать / скрывать кнопку повышения, потому что нельзя стать артистом, если профиль артиста уже был и отключен админом.